### PR TITLE
feat: connect AI agents to app pages (4 pages)

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -2970,6 +2970,10 @@ const NAV: { id: Section; label: string; desc: string }[] = [
 // ─────────────────────────────────────────────────────────────
 // PAGE ROOT
 // ─────────────────────────────────────────────────────────────
+// ── Types pour l'analyse IA ───────────────────────────────────
+interface AIPerformanceTrend { metric: string; direction: 'improving'|'stable'|'declining'; change: string }
+interface AIPerformanceResult { summary: string; trends: AIPerformanceTrend[]; strengths: string[]; weaknesses: string[]; recommendations: string[]; fitnessScore: number }
+
 export default function TrainingPage() {
   useTheme() // branche sur le thème global (force re-render quand dark/light change)
   const { activities, loading, error, reload } = useActivities()
@@ -2979,6 +2983,44 @@ export default function TrainingPage() {
   const [mobileOpen, setMobileOpen] = useState(false)
   const [syncing, setSyncing]       = useState(false)
   const [syncMsg, setSyncMsg]       = useState<string | null>(null)
+  const [aiLoading,  setAiLoading]  = useState(false)
+  const [aiResult,   setAiResult]   = useState<AIPerformanceResult | null>(null)
+  const [aiError,    setAiError]    = useState<string | null>(null)
+
+  async function analyzePerformance() {
+    if (activities.length === 0) return
+    setAiLoading(true); setAiResult(null); setAiError(null)
+    try {
+      const recent = activities.slice(0, 30)
+      const res = await fetch('/api/coach-engine', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'analyze_performance',
+          payload: {
+            activities: recent.map(a => ({
+              sport: a.sport_type,
+              date: a.started_at,
+              durationMin: Math.round((a.moving_time_s ?? 0) / 60),
+              distance: a.distance_m ?? undefined,
+              avgWatts: a.avg_watts ?? undefined,
+              tss: a.tss ?? 0,
+              hrAvg: a.avg_hr ?? undefined,
+            })),
+            metrics: {},
+            period: '30d',
+          },
+        }),
+      })
+      const data = await res.json()
+      if (!data.ok) throw new Error(data.error ?? 'Erreur agent')
+      setAiResult(data.result)
+    } catch (e: unknown) {
+      setAiError(e instanceof Error ? e.message : 'Erreur inconnue')
+    } finally {
+      setAiLoading(false)
+    }
+  }
   const width   = useWindowWidth()
   const isMobile = width < 768
   const active  = NAV.find(n => n.id === section)!
@@ -3029,6 +3071,19 @@ export default function TrainingPage() {
           {syncMsg && (
             <span style={{ fontSize: 11, color: syncMsg.startsWith('+') ? '#22c55e' : syncMsg === 'À jour' ? T.textMuted : '#ef4444',
               fontFamily: T.fontBody, fontWeight: 600 }}>{syncMsg}</span>
+          )}
+          {!loading && activities.length > 0 && (
+            <button
+              onClick={analyzePerformance}
+              disabled={aiLoading}
+              title="Analyser mes performances avec l'IA"
+              style={{ background: aiLoading ? T.bgAlt : 'rgba(91,111,255,0.10)', border: '1px solid rgba(91,111,255,0.35)', borderRadius: T.radiusSm,
+                color: aiLoading ? T.textMuted : '#5b6fff', cursor: aiLoading ? 'default' : 'pointer',
+                padding: '5px 12px', fontSize: 12, fontWeight: 700, fontFamily: T.fontDisplay,
+                opacity: aiLoading ? 0.6 : 1, whiteSpace: 'nowrap' as const }}
+            >
+              {aiLoading ? '⏳ Analyse…' : '🧠 Analyser'}
+            </button>
           )}
           <button
             onClick={syncStrava}
@@ -3158,6 +3213,78 @@ export default function TrainingPage() {
             <div style={{ marginBottom: 20 }}>
               <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: T.text, fontFamily: T.fontDisplay }}>{active.label}</h1>
               <p style={{ margin: '3px 0 0', fontSize: 12, color: T.textMuted, fontFamily: T.fontBody }}>{active.desc}</p>
+            </div>
+          )}
+
+          {/* ── Panneau analyse IA ── */}
+          {aiError && (
+            <div style={{ marginBottom: 16, padding: '12px 16px', borderRadius: T.radius, background: 'rgba(239,68,68,0.07)', border: '1px solid rgba(239,68,68,0.25)', color: '#ef4444', fontSize: 12 }}>
+              ⚠️ {aiError}
+            </div>
+          )}
+          {aiResult && (
+            <div style={{ marginBottom: 20, background: T.surface, border: `1px solid ${T.border}`, borderRadius: T.radius, padding: 20, boxShadow: T.shadow }}>
+              {/* Header */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16, flexWrap: 'wrap' as const, gap: 10 }}>
+                <div>
+                  <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: 1, color: T.textMuted, margin: 0, fontFamily: T.fontDisplay }}>Intelligence artificielle</p>
+                  <h3 style={{ fontFamily: T.fontDisplay, fontSize: 16, fontWeight: 700, margin: '3px 0 4px', color: T.text }}>Analyse de tes performances</h3>
+                  <p style={{ fontSize: 12, color: T.textSub, margin: 0, fontFamily: T.fontBody, lineHeight: 1.5 }}>{aiResult.summary}</p>
+                </div>
+                <div style={{ textAlign: 'center' as const, flexShrink: 0 }}>
+                  <p style={{ fontFamily: T.fontMono, fontSize: 34, fontWeight: 800, margin: 0, lineHeight: 1,
+                    color: aiResult.fitnessScore >= 75 ? '#22c55e' : aiResult.fitnessScore >= 50 ? '#f97316' : '#ef4444' }}>
+                    {aiResult.fitnessScore}
+                  </p>
+                  <p style={{ fontSize: 9, color: T.textMuted, margin: '2px 0 0', fontFamily: T.fontBody }}>score fitness / 100</p>
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 12, marginBottom: 14 }}>
+                {/* Tendances */}
+                {aiResult.trends.length > 0 && (
+                  <div style={{ padding: '12px 14px', borderRadius: T.radiusSm, background: T.bg, border: `1px solid ${T.border}` }}>
+                    <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: 0.8, color: T.textMuted, margin: '0 0 8px', fontFamily: T.fontDisplay }}>Tendances</p>
+                    {aiResult.trends.map((t, i) => (
+                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 5 }}>
+                        <span style={{ fontSize: 12 }}>{ t.direction === 'improving' ? '📈' : t.direction === 'declining' ? '📉' : '➡️' }</span>
+                        <div>
+                          <p style={{ fontSize: 11, fontWeight: 600, margin: 0, color: T.text }}>{t.metric}</p>
+                          <p style={{ fontSize: 10, color: T.textMuted, margin: 0, fontFamily: T.fontBody }}>{t.change}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Forces / Faiblesses */}
+                <div style={{ padding: '12px 14px', borderRadius: T.radiusSm, background: T.bg, border: `1px solid ${T.border}` }}>
+                  {aiResult.strengths.length > 0 && (
+                    <>
+                      <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: 0.8, color: '#22c55e', margin: '0 0 6px', fontFamily: T.fontDisplay }}>💪 Forces</p>
+                      {aiResult.strengths.map((s, i) => <p key={i} style={{ fontSize: 11, color: T.text, margin: '0 0 3px', fontFamily: T.fontBody }}>• {s}</p>)}
+                    </>
+                  )}
+                  {aiResult.weaknesses.length > 0 && (
+                    <>
+                      <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: 0.8, color: '#f97316', margin: '10px 0 6px', fontFamily: T.fontDisplay }}>⚠️ Points à travailler</p>
+                      {aiResult.weaknesses.map((w, i) => <p key={i} style={{ fontSize: 11, color: T.text, margin: '0 0 3px', fontFamily: T.fontBody }}>• {w}</p>)}
+                    </>
+                  )}
+                </div>
+
+                {/* Recommandations */}
+                {aiResult.recommendations.length > 0 && (
+                  <div style={{ padding: '12px 14px', borderRadius: T.radiusSm, background: T.bg, border: `1px solid ${T.border}` }}>
+                    <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: 0.8, color: '#5b6fff', margin: '0 0 8px', fontFamily: T.fontDisplay }}>💡 Recommandations</p>
+                    {aiResult.recommendations.map((r, i) => <p key={i} style={{ fontSize: 11, color: T.text, margin: '0 0 5px', fontFamily: T.fontBody }}>• {r}</p>)}
+                  </div>
+                )}
+              </div>
+
+              <button onClick={() => setAiResult(null)} style={{ padding: '5px 12px', borderRadius: T.radiusSm, background: T.bgAlt, border: `1px solid ${T.border}`, color: T.textMuted, fontSize: 11, cursor: 'pointer', fontFamily: T.fontBody, display: 'block', marginLeft: 'auto' }}>
+                ✕ Fermer
+              </button>
             </div>
           )}
 

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -995,23 +995,48 @@ function PlanQuestionnaireModal({ onClose, onGenerate }: { onClose:()=>void; onG
 // ══════════════════════════════════════════════════════════════════
 // AI CHAT PANEL
 // ══════════════════════════════════════════════════════════════════
-function AIChatPanel({ messages, onSend }: { messages:ChatMessage[]; onSend:(m:ChatMessage)=>void }) {
-  const [input, setInput] = useState('')
+function AIChatPanel({ messages, onSend, mealContext }: {
+  messages: ChatMessage[]
+  onSend: (m: ChatMessage) => void
+  mealContext?: { kcal:number; p:number; c:number; f:number; targetKcal:number }
+}) {
+  const [input,   setInput]   = useState('')
+  const [sending, setSending] = useState(false)
   const endRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => { endRef.current?.scrollIntoView({ behavior:'smooth' }) }, [messages])
 
-  function send() {
-    if (!input.trim()) return
-    const userMsg: ChatMessage = { id:uid(), role:'user', content:input, ts:nowTs() }
+  async function send() {
+    if (!input.trim() || sending) return
+    const question = input.trim()
+    const userMsg: ChatMessage = { id:uid(), role:'user', content:question, ts:nowTs() }
     onSend(userMsg)
-    const lower = input.toLowerCase()
-    const match = AI_RESPONSES.find(r => r.kw.some(k => lower.includes(k)))
-    const aiContent = match?.r ?? "Bonne question. Pour être précis, je te recommande de consulter ton plan nutritionnel et d'ajuster selon ton ressenti du jour. N'hésite pas à reformuler si tu veux une réponse plus spécifique."
-    setTimeout(() => {
-      onSend({ id:uid(), role:'ai', content:aiContent, ts:nowTs() })
-    }, 800)
     setInput('')
+    setSending(true)
+    try {
+      const res = await fetch('/api/coach-engine', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'nutrition',
+          payload: {
+            athleteProfile: { sport: 'multisport' },
+            goal: 'performance',
+            currentIntake: mealContext ? { kcal:mealContext.kcal, proteinG:mealContext.p, carbsG:mealContext.c, fatG:mealContext.f } : undefined,
+            question,
+          },
+        }),
+      })
+      const data = await res.json()
+      const answer = data.ok && data.result?.answer
+        ? data.result.answer
+        : "Désolé, je n'ai pas pu analyser ta question. Réessaie dans un instant."
+      onSend({ id:uid(), role:'ai', content:answer, ts:nowTs() })
+    } catch {
+      onSend({ id:uid(), role:'ai', content:"Erreur de connexion au coach IA. Réessaie dans un instant.", ts:nowTs() })
+    } finally {
+      setSending(false)
+    }
   }
 
   return (
@@ -1031,11 +1056,13 @@ function AIChatPanel({ messages, onSend }: { messages:ChatMessage[]; onSend:(m:C
       </div>
       {/* Input */}
       <div style={{ display:'flex', gap:8 }}>
-        <input value={input} onChange={e=>setInput(e.target.value)} onKeyDown={e=>e.key==='Enter'&&send()}
-          placeholder="Demande quelque chose…"
-          style={{ flex:1, borderRadius:12, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text-main)', padding:'10px 14px', fontFamily:'DM Sans,sans-serif', fontSize:13 }}/>
-        <button onClick={send} style={{ padding:'10px 16px', borderRadius:12, border:'none', background:'#00c8e0', color:'#fff', fontFamily:'Syne,sans-serif', fontSize:12, fontWeight:700, cursor:'pointer' }}>
-          Envoyer
+        <input value={input} onChange={e=>setInput(e.target.value)} onKeyDown={e=>e.key==='Enter'&&!sending&&send()}
+          placeholder={sending ? 'Coach IA répond…' : 'Pose ta question nutrition…'}
+          disabled={sending}
+          style={{ flex:1, borderRadius:12, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text-main)', padding:'10px 14px', fontFamily:'DM Sans,sans-serif', fontSize:13, opacity:sending?0.7:1 }}/>
+        <button onClick={send} disabled={sending}
+          style={{ padding:'10px 16px', borderRadius:12, border:'none', background:sending?'var(--bg-card2)':'#00c8e0', color:sending?'var(--text-dim)':'#fff', fontFamily:'Syne,sans-serif', fontSize:12, fontWeight:700, cursor:sending?'default':'pointer', minWidth:80 }}>
+          {sending ? '⏳' : 'Envoyer'}
         </button>
       </div>
     </div>
@@ -1113,8 +1140,9 @@ function SectionToday({ meals, plan, ctx }: { meals:Meal[]; plan:NutritionPlan|n
 // ══════════════════════════════════════════════════════════════════
 // SECTION 2 — PLAN & IA
 // ══════════════════════════════════════════════════════════════════
-function SectionPlan({ plan, ctx, onCreatePlan, showBody }: { plan:NutritionPlan|null; ctx:SportContext; onCreatePlan:()=>void; showBody:boolean }) {
+function SectionPlan({ plan, ctx, onCreatePlan, showBody, todayTotals }: { plan:NutritionPlan|null; ctx:SportContext; onCreatePlan:()=>void; showBody:boolean; todayTotals?:{kcal:number;p:number;c:number;f:number} }) {
   const [aiMsgs, setAiMsgs] = useState<ChatMessage[]>(MOCK_CHAT)
+  const target = plan ? plan[ctx.today_type] : null
 
   function handleSend(m: ChatMessage) { setAiMsgs(prev => [...prev, m]) }
 
@@ -1225,7 +1253,7 @@ function SectionPlan({ plan, ctx, onCreatePlan, showBody }: { plan:NutritionPlan
 
       {/* AI Chat */}
       <div style={{ borderTop:'1px solid var(--border)', paddingTop:20 }}>
-        <AIChatPanel messages={aiMsgs} onSend={handleSend}/>
+        <AIChatPanel messages={aiMsgs} onSend={handleSend} mealContext={todayTotals ? { ...todayTotals, targetKcal: target?.kcal ?? 2500 } : undefined}/>
       </div>
 
       <style>{`
@@ -1383,6 +1411,7 @@ export default function NutritionPage() {
   const [showQModal,    setShowQModal]  = useState(false)
   const [sportCtx]                      = useState<SportContext>(MOCK_SPORT_CONTEXT)
   const hasBodyData                     = MOCK_BODY.length > 0
+  const todayTotals                     = totalDay(meals)
 
   return (
     <div style={{ padding:'24px 28px', maxWidth:'100%' }}>
@@ -1410,7 +1439,7 @@ export default function NutritionPage() {
       </div>
 
       <SectionToday meals={meals} plan={plan} ctx={sportCtx}/>
-      <SectionPlan  plan={plan} ctx={sportCtx} onCreatePlan={()=>setShowQModal(true)} showBody={hasBodyData}/>
+      <SectionPlan  plan={plan} ctx={sportCtx} onCreatePlan={()=>setShowQModal(true)} showBody={hasBodyData} todayTotals={{ kcal:todayTotals.kcal, p:todayTotals.p, c:todayTotals.c, f:todayTotals.f }}/>
       <SectionMeals meals={meals} setMeals={setMeals}/>
 
       {showQModal && (

--- a/src/app/recovery/page.tsx
+++ b/src/app/recovery/page.tsx
@@ -3,6 +3,16 @@
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 
+// ── Types pour l'analyse IA ───────────────────────────────────
+interface AIReadinessResult {
+  score: number
+  readinessLevel: 'low' | 'moderate' | 'good' | 'excellent'
+  fatigue: number
+  recommendation: string
+  trainingLoad: 'reduce' | 'maintain' | 'increase'
+  todayAdvice: string
+}
+
 // ══════════════════════════════════════════════
 // MOCK DATA — supprimer quand Supabase branché
 // Remplacer par : const data = await supabase.from('recovery_daily_logs')...
@@ -249,21 +259,32 @@ interface CheckInData {
 // ══════════════════════════════════════════════
 // SECTION 1 — TODAY
 // ══════════════════════════════════════════════
-function SectionToday({ data, onCheckIn }: { data: typeof MOCK; onCheckIn: () => void }) {
+function SectionToday({ data, onCheckIn, onAIAnalysis, aiLoading }: {
+  data: typeof MOCK
+  onCheckIn: () => void
+  onAIAnalysis: () => void
+  aiLoading: boolean
+}) {
   const status = readinessStatus(data.readiness)
 
   return (
     <div style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:20, padding:24, boxShadow:'var(--shadow-card)', marginBottom:16 }}>
       {/* Header bulle */}
-      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:20 }}>
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:20, flexWrap:'wrap' as const, gap:8 }}>
         <div>
           <p style={{ fontSize:10, fontWeight:600, textTransform:'uppercase', letterSpacing:'0.1em', color:'var(--text-dim)', margin:0 }}>Today</p>
           <h2 style={{ fontFamily:'Syne,sans-serif', fontSize:18, fontWeight:700, margin:'3px 0 0' }}>État du jour</h2>
         </div>
-        <button onClick={onCheckIn}
-          style={{ padding:'8px 16px', borderRadius:10, background:'linear-gradient(135deg,#00c8e0,#5b6fff)', border:'none', color:'#fff', fontFamily:'Syne,sans-serif', fontWeight:600, fontSize:12, cursor:'pointer', whiteSpace:'nowrap' }}>
-          Check-in du matin
-        </button>
+        <div style={{ display:'flex', gap:8 }}>
+          <button onClick={onAIAnalysis} disabled={aiLoading}
+            style={{ padding:'8px 14px', borderRadius:10, background:'rgba(91,111,255,0.10)', border:'1px solid rgba(91,111,255,0.35)', color:'#5b6fff', fontFamily:'Syne,sans-serif', fontWeight:600, fontSize:12, cursor:aiLoading?'default':'pointer', whiteSpace:'nowrap' as const, opacity:aiLoading?0.6:1 }}>
+            {aiLoading ? '⏳ Analyse…' : '🧠 Analyse IA'}
+          </button>
+          <button onClick={onCheckIn}
+            style={{ padding:'8px 16px', borderRadius:10, background:'linear-gradient(135deg,#00c8e0,#5b6fff)', border:'none', color:'#fff', fontFamily:'Syne,sans-serif', fontWeight:600, fontSize:12, cursor:'pointer', whiteSpace:'nowrap' as const }}>
+            Check-in du matin
+          </button>
+        </div>
       </div>
 
       {/* Grid principal */}
@@ -627,6 +648,43 @@ function SectionDataSources() {
 export default function RecoveryPage() {
   const [showCheckIn, setShowCheckIn] = useState(false)
   const [todayData, setTodayData]     = useState(MOCK)
+  const [aiLoading,  setAiLoading]    = useState(false)
+  const [aiResult,   setAiResult]     = useState<AIReadinessResult | null>(null)
+  const [aiError,    setAiError]      = useState<string | null>(null)
+
+  async function handleAIAnalysis() {
+    setAiLoading(true); setAiResult(null); setAiError(null)
+    try {
+      const res = await fetch('/api/coach-engine', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'readiness_check',
+          payload: {
+            recentActivities: todayData.trends.days7.readiness.map((r, i) => ({
+              sport: 'multisport',
+              date: new Date(Date.now() - (6 - i) * 86400000).toISOString().split('T')[0],
+              durationMin: 45,
+              tss: Math.round(r * 0.7),
+              rpe: todayData.trends.days7.fatigue[i],
+            })),
+            sleepQuality: todayData.sleep.quality,
+            subjectiveFeeling: todayData.energy,
+            hrv: todayData.hrv ?? undefined,
+            restingHR: todayData.restingHr ?? undefined,
+            notes: `Fatigue: ${todayData.fatigue}/10, Stress: ${todayData.stress}/10, Motivation: ${todayData.motivation}/10, Douleurs: ${todayData.pain}/10`,
+          },
+        }),
+      })
+      const data = await res.json()
+      if (!data.ok) throw new Error(data.error ?? 'Erreur agent')
+      setAiResult(data.result)
+    } catch (e: unknown) {
+      setAiError(e instanceof Error ? e.message : 'Erreur inconnue')
+    } finally {
+      setAiLoading(false)
+    }
+  }
 
   function handleCheckIn(d: CheckInData) {
     // Mettre à jour les données locales (mock)
@@ -655,7 +713,72 @@ export default function RecoveryPage() {
         </p>
       </div>
 
-      <SectionToday    data={todayData} onCheckIn={() => setShowCheckIn(true)}/>
+      <SectionToday    data={todayData} onCheckIn={() => setShowCheckIn(true)} onAIAnalysis={handleAIAnalysis} aiLoading={aiLoading}/>
+
+      {/* ── Résultat analyse IA ─────────────────────────── */}
+      {aiError && (
+        <div style={{ padding:'12px 18px', borderRadius:14, background:'rgba(239,68,68,0.07)', border:'1px solid rgba(239,68,68,0.25)', color:'#ef4444', fontSize:12, marginBottom:16 }}>
+          ⚠️ {aiError}
+        </div>
+      )}
+      {aiResult && (
+        <div style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:20, padding:24, boxShadow:'var(--shadow-card)', marginBottom:16 }}>
+          <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:18, flexWrap:'wrap' as const, gap:12 }}>
+            <div>
+              <p style={{ fontSize:10, fontWeight:600, textTransform:'uppercase' as const, letterSpacing:'0.1em', color:'var(--text-dim)', margin:0 }}>Analyse IA</p>
+              <h2 style={{ fontFamily:'Syne,sans-serif', fontSize:18, fontWeight:700, margin:'3px 0 0' }}>Coaching du jour</h2>
+            </div>
+            <div style={{ display:'flex', alignItems:'center', gap:14 }}>
+              <div style={{ textAlign:'center' as const }}>
+                <p style={{ fontFamily:'Syne,sans-serif', fontSize:32, fontWeight:800, margin:0, lineHeight:1,
+                  color: aiResult.score >= 80 ? '#22c55e' : aiResult.score >= 60 ? '#00c8e0' : aiResult.score >= 40 ? '#f97316' : '#ef4444' }}>
+                  {aiResult.score}
+                </p>
+                <p style={{ fontSize:9, color:'var(--text-dim)', margin:'2px 0 0' }}>/ 100</p>
+              </div>
+              <div style={{ padding:'6px 14px', borderRadius:99, fontSize:12, fontWeight:700,
+                background: aiResult.readinessLevel === 'excellent' ? 'rgba(34,197,94,0.12)' : aiResult.readinessLevel === 'good' ? 'rgba(0,200,224,0.12)' : aiResult.readinessLevel === 'moderate' ? 'rgba(249,115,22,0.12)' : 'rgba(239,68,68,0.12)',
+                color: aiResult.readinessLevel === 'excellent' ? '#22c55e' : aiResult.readinessLevel === 'good' ? '#00c8e0' : aiResult.readinessLevel === 'moderate' ? '#f97316' : '#ef4444',
+                border: '1px solid currentColor' }}>
+                {{ low:'Faible', moderate:'Modéré', good:'Bonne forme', excellent:'Optimal' }[aiResult.readinessLevel]}
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display:'flex', flexDirection:'column', gap:12 }}>
+            {/* Charge recommandée */}
+            <div style={{ display:'flex', alignItems:'center', gap:10, padding:'12px 16px', borderRadius:12,
+              background: aiResult.trainingLoad === 'reduce' ? 'rgba(239,68,68,0.07)' : aiResult.trainingLoad === 'increase' ? 'rgba(34,197,94,0.07)' : 'rgba(0,200,224,0.07)',
+              border: `1px solid ${aiResult.trainingLoad === 'reduce' ? 'rgba(239,68,68,0.25)' : aiResult.trainingLoad === 'increase' ? 'rgba(34,197,94,0.25)' : 'rgba(0,200,224,0.25)'}` }}>
+              <span style={{ fontSize:20 }}>{ aiResult.trainingLoad === 'reduce' ? '🔽' : aiResult.trainingLoad === 'increase' ? '🔼' : '➡️' }</span>
+              <div>
+                <p style={{ fontSize:11, fontWeight:700, margin:0, color: aiResult.trainingLoad === 'reduce' ? '#ef4444' : aiResult.trainingLoad === 'increase' ? '#22c55e' : '#00c8e0' }}>
+                  Charge : { aiResult.trainingLoad === 'reduce' ? 'Réduire' : aiResult.trainingLoad === 'increase' ? 'Augmenter' : 'Maintenir' }
+                </p>
+                <p style={{ fontSize:11, color:'var(--text-mid)', margin:'2px 0 0' }}>{aiResult.recommendation}</p>
+              </div>
+            </div>
+            {/* Conseil séance */}
+            <div style={{ padding:'12px 16px', borderRadius:12, background:'rgba(91,111,255,0.07)', border:'1px solid rgba(91,111,255,0.2)' }}>
+              <p style={{ fontSize:11, fontWeight:600, color:'#5b6fff', margin:'0 0 4px' }}>💡 Séance du jour</p>
+              <p style={{ fontSize:13, color:'var(--text)', margin:0, lineHeight:1.6 }}>{aiResult.todayAdvice}</p>
+            </div>
+            {/* Fatigue bar */}
+            <div>
+              <div style={{ display:'flex', justifyContent:'space-between', marginBottom:4 }}>
+                <span style={{ fontSize:10, color:'var(--text-dim)', fontWeight:600, textTransform:'uppercase' as const, letterSpacing:'0.05em' }}>Fatigue estimée</span>
+                <span style={{ fontSize:11, fontFamily:'DM Mono,monospace', color:'var(--text)' }}>{aiResult.fatigue}/100</span>
+              </div>
+              <div style={{ height:5, borderRadius:99, background:'var(--border)', overflow:'hidden' }}>
+                <div style={{ height:'100%', width:`${aiResult.fatigue}%`, borderRadius:99,
+                  background: aiResult.fatigue > 70 ? '#ef4444' : aiResult.fatigue > 45 ? '#f97316' : '#22c55e' }}/>
+              </div>
+            </div>
+          </div>
+          <button onClick={() => setAiResult(null)} style={{ marginTop:16, padding:'5px 12px', borderRadius:8, background:'var(--bg-card2)', border:'1px solid var(--border)', color:'var(--text-dim)', fontSize:11, cursor:'pointer', display:'block', marginLeft:'auto' }}>✕ Fermer</button>
+        </div>
+      )}
+
       <SectionSleep    sleep={todayData.sleep}/>
       <SectionTrends   data={todayData}/>
       <SectionDataSources/>

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -981,6 +981,10 @@ function TemplateCard({ t, onStart, onEdit }: { t: SessionTemplate; onStart:()=>
 // ══════════════════════════════════════════════════════════════════
 // BUILD MODE — full session form + sport builder
 // ══════════════════════════════════════════════════════════════════
+// ── Types pour l'agent IA session ────────────────────────────
+interface AISessionBlock { type:'warmup'|'effort'|'recovery'|'cooldown'; zone:number; durationMin:number; label:string; description?:string }
+interface AISessionResult { title:string; blocks:AISessionBlock[]; totalDurationMin:number; estimatedTSS:number; coachNotes:string }
+
 function BuildMode({ initial, onSave, onCancel }: {
   initial?: SessionTemplate
   onSave: (t: SessionTemplate) => void
@@ -992,6 +996,39 @@ function BuildMode({ initial, onSave, onCancel }: {
   const [intensity, setIntensity] = useState<Intensity>(initial?.intensity ?? 'moderate')
   const [tagsStr,   setTagsStr]   = useState((initial?.tags??[]).join(', '))
   const [notes,     setNotes]     = useState(initial?.notes ?? '')
+
+  const [aiLoading,   setAiLoading]   = useState(false)
+  const [aiResult,    setAiResult]    = useState<AISessionResult | null>(null)
+  const [aiError,     setAiError]     = useState<string | null>(null)
+
+  async function generateWithAI() {
+    setAiLoading(true); setAiResult(null); setAiError(null)
+    const sportToApi: Record<Sport, string> = { muscu:'gym', running:'run', velo:'bike', natation:'swim', hyrox:'hyrox' }
+    const intensityToType: Record<Intensity, string> = { low:'recovery', moderate:'endurance', high:'intervals', max:'intervals' }
+    try {
+      const res = await fetch('/api/coach-engine', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'build_session',
+          payload: {
+            sport: sportToApi[sport],
+            type: intensityToType[intensity],
+            targetDurationMin: duration,
+            context: notes || `${sportLabel(sport)} — ${intensityLabel(intensity)}`,
+          },
+        }),
+      })
+      const data = await res.json()
+      if (!data.ok) throw new Error(data.error ?? 'Erreur agent')
+      setAiResult(data.result)
+      if (data.result.title && !name) setName(data.result.title)
+    } catch (e: unknown) {
+      setAiError(e instanceof Error ? e.message : 'Erreur inconnue')
+    } finally {
+      setAiLoading(false)
+    }
+  }
 
   const [muscu,    setMuscu]    = useState<MusculaireSession>(initial?.muscu    ?? { circuits:[], exercises:[] })
   const [endur,    setEndur]    = useState<EnduranceSession>(initial?.endurance ?? { blocks:[] })
@@ -1028,11 +1065,49 @@ function BuildMode({ initial, onSave, onCancel }: {
               {name || 'Seance sans titre'}
             </h2>
           </div>
-          <button onClick={onCancel}
-            style={{ background:'var(--bg-card2)', border:'1px solid var(--border)', borderRadius:8, padding:'6px 12px', cursor:'pointer', color:'var(--text-dim)', fontSize:13, fontFamily:'DM Sans,sans-serif' }}>
-            Annuler
-          </button>
+          <div style={{ display:'flex', gap:8 }}>
+            <button onClick={generateWithAI} disabled={aiLoading}
+              style={{ padding:'7px 14px', borderRadius:9, background:'rgba(91,111,255,0.10)', border:'1px solid rgba(91,111,255,0.35)', color:'#5b6fff', fontFamily:'DM Sans,sans-serif', fontSize:12, fontWeight:700, cursor:aiLoading?'default':'pointer', opacity:aiLoading?0.6:1, whiteSpace:'nowrap' as const }}>
+              {aiLoading ? '⏳ Génération…' : '✨ Générer avec l\'IA'}
+            </button>
+            <button onClick={onCancel}
+              style={{ background:'var(--bg-card2)', border:'1px solid var(--border)', borderRadius:8, padding:'6px 12px', cursor:'pointer', color:'var(--text-dim)', fontSize:13, fontFamily:'DM Sans,sans-serif' }}>
+              Annuler
+            </button>
+          </div>
         </div>
+
+        {/* ── Résultat IA ── */}
+        {aiError && (
+          <div style={{ marginBottom:14, padding:'10px 14px', borderRadius:10, background:'rgba(239,68,68,0.07)', border:'1px solid rgba(239,68,68,0.25)', color:'#ef4444', fontSize:12 }}>
+            ⚠️ {aiError}
+          </div>
+        )}
+        {aiResult && (
+          <div style={{ marginBottom:20, padding:'16px', borderRadius:14, background:'rgba(91,111,255,0.06)', border:'1px solid rgba(91,111,255,0.2)' }}>
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:12 }}>
+              <p style={{ fontFamily:'Syne,sans-serif', fontSize:14, fontWeight:700, margin:0, color:'#5b6fff' }}>✨ {aiResult.title}</p>
+              <span style={{ fontSize:10, fontFamily:'DM Mono,monospace', color:'var(--text-dim)' }}>{aiResult.totalDurationMin}min · TSS ~{aiResult.estimatedTSS}</span>
+            </div>
+            <div style={{ display:'flex', flexDirection:'column', gap:4, marginBottom:12 }}>
+              {aiResult.blocks.map((b, i) => {
+                const zoneColors = ['#9ca3af','#22c55e','#eab308','#f97316','#ef4444']
+                const c = zoneColors[Math.min(b.zone - 1, 4)] ?? '#9ca3af'
+                return (
+                  <div key={i} style={{ display:'flex', alignItems:'center', gap:10, padding:'7px 12px', borderRadius:8, background:'var(--bg-card2)', borderLeft:`3px solid ${c}` }}>
+                    <span style={{ fontFamily:'DM Mono,monospace', fontSize:10, color:c, fontWeight:700, minWidth:26 }}>Z{b.zone}</span>
+                    <span style={{ fontSize:11, fontWeight:600, flex:1 }}>{b.label}</span>
+                    <span style={{ fontSize:10, color:'var(--text-dim)', fontFamily:'DM Mono,monospace' }}>{b.durationMin}min</span>
+                  </div>
+                )
+              })}
+            </div>
+            {aiResult.coachNotes && (
+              <p style={{ fontSize:11, color:'var(--text-mid)', margin:'0 0 10px', fontStyle:'italic' as const }}>💬 {aiResult.coachNotes}</p>
+            )}
+            <button onClick={() => setAiResult(null)} style={{ padding:'4px 10px', borderRadius:7, background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text-dim)', fontSize:10, cursor:'pointer' }}>✕ Fermer</button>
+          </div>
+        )}
 
         {/* Nom */}
         <div style={{ marginBottom:14 }}>


### PR DESCRIPTION
Recovery → readinessAgent
- "🧠 Analyse IA" button in SectionToday header
- Result card: score, readinessLevel, trainingLoad, todayAdvice, fatigue bar

Session/BuildMode → sessionBuilderAgent
- "✨ Générer avec l'IA" button in build header
- Result panel: blocks with zone colors, coachNotes, TSS estimate
- Auto-fills session title if empty

Nutrition/AIChatPanel → nutritionAgent (replaces keyword mock)
- Real async fetch to /api/coach-engine with action:"nutrition"
- Passes current meal macros as context (kcal, P, C, L)
- Loading state: button shows ⏳, input disabled while waiting

Activities → performanceAgent
- "🧠 Analyser" button in top bar (visible when activities loaded)
- Result panel: fitness score, trends (📈📉), forces/faiblesses, recommandations
- Uses last 30 activities as input