### PR TITLE
feat(planning): Phase 5 - badge modifie, reset seance, PDF export, chat plan-aware + fixes

### DIFF
--- a/src/app/api/training-plan/route.ts
+++ b/src/app/api/training-plan/route.ts
@@ -44,10 +44,9 @@ interface PlanSemaine {
   volume_h: number
   tss_semaine: number
   theme: string
-  // Semaines détaillées (S1-S2)
-  seances?: PlanSeance[]
-  // Semaines résumées (S3+)
   note_coach?: string
+  // Toutes les semaines ont des séances ; les blocs sont détaillés S1-S2 uniquement
+  seances?: PlanSeance[]
 }
 
 interface PlanPeriodisation {
@@ -94,13 +93,13 @@ const JSON_SCHEMA = `{
   ],
   "semaines": [
     {
-      "SEMAINES 1 et 2 — format détaillé": {
-        "numero": "number",
-        "type": "string",
-        "volume_h": "number",
-        "tss_semaine": "number",
-        "theme": "string (1 phrase courte)",
-        "seances": [
+      "numero": "number",
+      "type": "string",
+      "volume_h": "number",
+      "tss_semaine": "number",
+      "theme": "string (1 phrase courte)",
+      "note_coach": "string (1 phrase de coaching)",
+      "seances": [
           {
             "jour": "number (0=lundi, 6=dimanche)",
             "sport": "string",
@@ -109,7 +108,7 @@ const JSON_SCHEMA = `{
             "tss": "number",
             "intensite": "low | moderate | high | max",
             "heure": "string (ex: 06:30)",
-            "notes": "string (1 phrase)",
+            "notes": "string (1 phrase, ≤12 mots)",
             "rpe": "number",
             "blocs": [
               {
@@ -120,20 +119,11 @@ const JSON_SCHEMA = `{
                 "recup_min": "number",
                 "watts": "number | null",
                 "allure": "string | null",
-                "consigne": "string (1 phrase)"
+                "consigne": "string (1 phrase, ≤10 mots)"
               }
             ]
           }
-        ]
-      },
-      "SEMAINES 3+ — format résumé UNIQUEMENT": {
-        "numero": "number",
-        "type": "string",
-        "volume_h": "number",
-        "tss_semaine": "number",
-        "theme": "string (1 phrase courte)",
-        "note_coach": "string (1 phrase)"
-      }
+      ]
     }
   ],
   "conseils_adaptation": ["string (3 max)"],
@@ -312,13 +302,15 @@ ${JSON.stringify(sante ?? [], null, 2)}
 
 ${modification ? `MODIFICATION DEMANDÉE :\n${modification}\n\nPROGRAMME EXISTANT :\n${JSON.stringify(programme_actuel ?? null, null, 2)}` : ''}
 
-INSTRUCTIONS CRITIQUES POUR LA TAILLE DE LA RÉPONSE :
-- Génère UNIQUEMENT les 2 premières semaines avec le détail complet des séances et des blocs.
-- Pour les semaines 3 et suivantes, inclure UNIQUEMENT : numero, type, volume_h, tss_semaine, theme, note_coach. SANS les séances ni les blocs.
+INSTRUCTIONS POUR LA GÉNÉRATION — RESPECTER IMPÉRATIVEMENT :
+- Génère le détail complet des séances (seances[]) pour TOUTES les semaines du plan, sans exception.
+- Pour chaque séance de chaque semaine : sport, titre, jour, duree_min, tss, intensite, heure, notes, rpe.
+- Les blocs détaillés (blocs[]) : UNIQUEMENT pour les semaines 1 et 2. Pour les semaines 3+, mettre blocs à [] (tableau vide).
+- Note_coach : OBLIGATOIRE pour chaque semaine, 1 phrase de coaching contextuelle.
 - Limite conseils_adaptation à 3 éléments maximum.
 - Limite points_cles à 3 éléments maximum.
-- Chaque "consigne" et "notes" doivent tenir en 1 phrase courte.
-- Cette contrainte est OBLIGATOIRE pour éviter la troncature du JSON.
+- Chaque "consigne" ≤ 10 mots, chaque "notes" ≤ 12 mots — concision obligatoire pour tenir dans les tokens.
+- Ne jamais omettre les séances d'une semaine, même en fin de plan.
 
 Génère selon ce schéma JSON (UNIQUEMENT le JSON, rien d'autre) :
 ${JSON_SCHEMA}

--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -102,6 +102,8 @@ interface Session {
   id:string; sport:SportType; title:string; time:string; durationMin:number
   tss?:number; main?:boolean; status:SessionStatus; notes?:string; blocks:Block[]
   rpe?:number; dayIndex:number; planVariant?:PlanVariant
+  // Phase 5 — snapshot immuable de la version IA (pour badge "modifié" + reset)
+  originalContent?: Record<string, unknown>
   vDuration?:string; vDistance?:string; vElevation?:string; vSpeed?:string
   vHrAvg?:string; vPace?:string
   vHyroxStations?: Record<string,string>; vHyroxRuns?: string[]
@@ -136,6 +138,17 @@ function formatHM(totalMin:number):string {
 // Keep formatDur as alias for backward compat in display
 function formatDur(min:number):string { return formatHM(min) }
 function daysUntil(d:string):number { return Math.ceil((new Date(d).getTime()-Date.now())/(1000*60*60*24)) }
+
+// Phase 5 — Détecte si la séance a été modifiée par l'athlète vs la version IA originale
+function isSessionModified(s: Session): boolean {
+  if (!s.originalContent) return false
+  const o = s.originalContent
+  if (typeof o.titre === 'string' && o.titre !== s.title) return true
+  if (typeof o.duration_min === 'number' && o.duration_min !== s.durationMin) return true
+  if (typeof o.notes === 'string' && (o.notes || '') !== (s.notes || '')) return true
+  if (typeof o.rpe === 'number' && o.rpe !== (s.rpe ?? null)) return true
+  return false
+}
 function calcSpeed(km:string,t:string):string { const d=parseFloat(km),m=parseFloat(t); if(!d||!m)return '—'; return `${(d/(m/60)).toFixed(1)} km/h` }
 
 // Normalise un bloc en provenance de planned_sessions.blocks (JSONB) vers
@@ -386,6 +399,7 @@ function usePlanning(weekStartParam?:string) {
       time:r.time??'09:00', durationMin:r.duration_min, tss:r.tss,
       status:r.status, notes:r.notes, rpe:r.rpe, blocks:normalizeBlocks(r.blocks), main:false,
       planVariant:r.plan_variant??'A',
+      originalContent: r.original_content ?? undefined,
       ...(r.validation_data??{}),
     })))
     setTasks((t.data??[]).map((r:any):WeekTask=>({
@@ -939,6 +953,113 @@ function AiPlanBubble({ plan }: { plan: AiTrainingPlan }) {
   )
 }
 
+// ── Phase 5 — Export PDF du plan complet ─────────────────────────────────
+function exportPlanToPDF(plan: AiTrainingPlan) {
+  const semaines = plan.ai_context?.program?.semaines ?? []
+  const SPORT_NAMES: Record<string, string> = {
+    run:'Course à pied', bike:'Cyclisme', swim:'Natation',
+    hyrox:'Hyrox', gym:'Musculation', rowing:'Aviron',
+  }
+  const INTENS_LABEL_PDF: Record<string, string> = {
+    low:'Endurance', moderate:'Tempo / Z3', high:'Intensif / Z4', max:'VO2max / Z5',
+  }
+  const html = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>${plan.name}</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, system-ui, sans-serif; background: #fff; color: #111; padding: 28px 32px; font-size: 13px; line-height: 1.5; }
+  h1 { font-size: 22px; font-weight: 800; margin-bottom: 4px; }
+  .meta { font-size: 12px; color: #666; margin-bottom: 4px; }
+  .objectif { font-size: 13px; color: #444; margin: 8px 0 16px; padding: 10px 14px; border-left: 3px solid #8b5cf6; background: #f5f3ff; border-radius: 0 8px 8px 0; }
+  .week { margin-bottom: 22px; page-break-inside: avoid; }
+  .week-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; padding: 6px 10px; background: #f3f4f6; border-radius: 6px; display: flex; justify-content: space-between; }
+  .week-note { font-size: 11px; color: #6b7280; font-style: italic; margin-bottom: 8px; padding-left: 4px; }
+  .sessions { display: flex; flex-direction: column; gap: 6px; }
+  .session { padding: 8px 12px; border-left: 3px solid #8b5cf6; border-radius: 0 8px 8px 0; background: #fafafa; }
+  .session-header { display: flex; align-items: center; gap: 8px; }
+  .session-sport { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; background: #8b5cf622; color: #8b5cf6; padding: 2px 6px; border-radius: 99px; flex-shrink: 0; }
+  .session-title { font-weight: 600; font-size: 13px; }
+  .session-meta { font-size: 11px; color: #6b7280; margin-top: 3px; }
+  .session-notes { font-size: 11px; color: #444; margin-top: 4px; font-style: italic; }
+  .blocs { margin-top: 8px; border-top: 1px solid #e5e7eb; padding-top: 6px; }
+  .bloc { font-size: 11px; color: #374151; padding: 2px 0; }
+  .day-badge { font-size: 10px; background: #e5e7eb; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
+  .footer { margin-top: 28px; border-top: 1px solid #e5e7eb; padding-top: 14px; font-size: 10px; color: #9ca3af; }
+  @media print {
+    body { padding: 16px 20px; }
+    .week { page-break-inside: avoid; }
+    @page { margin: 1.2cm; }
+  }
+</style>
+</head>
+<body>
+<h1>${plan.name}</h1>
+<p class="meta">Plan ${plan.duree_semaines} semaines · Du ${plan.start_date} au ${plan.end_date} · Sports : ${plan.sports.map(s => SPORT_NAMES[s] ?? s).join(', ')}</p>
+${plan.objectif_principal ? `<div class="objectif">${plan.objectif_principal}</div>` : ''}
+${semaines.map((sem) => {
+  const seances = (Array.isArray(sem.seances) ? sem.seances : []) as Record<string, unknown>[]
+  return `<div class="week">
+  <div class="week-title"><span>Semaine ${sem.numero}</span><span style="font-weight:400;color:#6b7280">${seances.length} séance${seances.length !== 1 ? 's' : ''}</span></div>
+  ${sem.note_coach ? `<div class="week-note">${sem.note_coach}</div>` : ''}
+  <div class="sessions">
+  ${seances.map((s: Record<string, unknown>) => {
+    const sport = typeof s.sport === 'string' ? s.sport : ''
+    const sportNorm = Object.entries(SPORT_NAMES).find(([,v]) => v.toLowerCase() === sport.toLowerCase())?.[0] ?? sport.toLowerCase()
+    const sportLabel = SPORT_NAMES[sportNorm] ?? sport
+    const titre = typeof s.titre === 'string' ? s.titre : ''
+    const jour = typeof s.jour === 'number' ? s.jour : null
+    const dureMin = typeof s.duree_min === 'number' ? s.duree_min : null
+    const tss = typeof s.tss === 'number' ? s.tss : null
+    const intensite = typeof s.intensite === 'string' ? s.intensite : null
+    const notes = typeof s.notes === 'string' ? s.notes : null
+    const blocs = Array.isArray(s.blocs) ? s.blocs as Record<string, unknown>[] : []
+    const DAY_NAMES_PDF = ['Lun','Mar','Mer','Jeu','Ven','Sam','Dim']
+    const dayLabel = jour !== null ? `Jour ${jour} — ${DAY_NAMES_PDF[jour] ?? ''}` : ''
+    const metaParts = [
+      dureMin ? `${Math.floor(dureMin / 60) > 0 ? Math.floor(dureMin / 60) + 'h' : ''}${dureMin % 60 > 0 ? (dureMin % 60) + 'min' : ''}` : null,
+      tss ? `${tss} TSS` : null,
+      intensite ? (INTENS_LABEL_PDF[intensite] ?? intensite) : null,
+    ].filter(Boolean)
+    return `<div class="session">
+    <div class="session-header">
+      ${dayLabel ? `<span class="day-badge">${dayLabel}</span>` : ''}
+      <span class="session-sport">${sportLabel}</span>
+      <span class="session-title">${titre}</span>
+    </div>
+    ${metaParts.length ? `<div class="session-meta">${metaParts.join(' · ')}</div>` : ''}
+    ${notes ? `<div class="session-notes">${notes}</div>` : ''}
+    ${blocs.length > 0 ? `<div class="blocs">${blocs.map((b: Record<string, unknown>) => {
+      const nom = typeof b.nom === 'string' ? b.nom : ''
+      const duree = typeof b.duree_min === 'number' ? b.duree_min : null
+      const zone = typeof b.zone === 'number' ? b.zone : null
+      const reps = typeof b.repetitions === 'number' && b.repetitions > 1 ? b.repetitions : null
+      const parts = [
+        nom,
+        reps ? `${reps}×${duree}min` : (duree ? `${duree}min` : null),
+        zone ? `Z${zone}` : null,
+      ].filter(Boolean)
+      return `<div class="bloc">· ${parts.join(' — ')}</div>`
+    }).join('')}</div>` : ''}
+    </div>`
+  }).join('')}
+  </div>
+</div>`
+}).join('')}
+<div class="footer">Exporté depuis THW Coaching · Plan généré par le Coach IA · ${new Date().toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}</div>
+</body>
+</html>`
+
+  const w = window.open('', '_blank')
+  if (w) {
+    w.document.write(html)
+    w.document.close()
+    setTimeout(() => { w.print() }, 400)
+  }
+}
+
 // ── Plan header + 4 collapsible charts ────────────────────────────────────
 
 function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
@@ -976,7 +1097,21 @@ function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
               <div style={{ width: `${(currentWeekNum / plan.duree_semaines) * 100}%`, height: '100%', background: 'linear-gradient(90deg,#8b5cf6,#5b6fff)', transition: 'width 0.3s ease' }} />
             </div>
           </div>
-          <p style={{ fontSize: 10, color: 'var(--text-dim)', margin: '4px 0 0' }}>Du {fmtFrenchDate(plan.start_date)} au {fmtFrenchDate(plan.end_date)}</p>
+          <div style={{ display:'flex', alignItems:'center', gap:10, marginTop:4 }}>
+            <p style={{ fontSize: 10, color: 'var(--text-dim)', margin: 0 }}>Du {fmtFrenchDate(plan.start_date)} au {fmtFrenchDate(plan.end_date)}</p>
+            <button
+              onClick={() => exportPlanToPDF(plan)}
+              title="Exporter le plan complet en PDF"
+              style={{
+                padding:'2px 8px', borderRadius:6,
+                background:'transparent', border:'1px solid var(--border)',
+                color:'var(--text-dim)', fontSize:10, cursor:'pointer',
+                display:'flex', alignItems:'center', gap:3, flexShrink:0,
+              }}
+            >
+              <span>↓</span> PDF
+            </button>
+          </div>
         </div>
 
         {/* ── Prochain objectif ── */}
@@ -1779,6 +1914,7 @@ function TrainingTab() {
                   <div key={s.id} draggable onDragStart={()=>onDragStart(s.id,i)} onTouchStart={()=>onTouchStart(s.id,i)} onClick={()=>setDetailModal(s)}
                     style={{ borderRadius:6,padding:'4px 6px',background:SPORT_BG[s.sport],borderLeft:`2px solid ${SPORT_BORDER[s.sport]}`,cursor:'grab',opacity:s.status==='done'?0.75:1,position:'relative' }}>
                     {s.status==='done' && <span style={{ position:'absolute',top:2,right:2,fontSize:7,background:SPORT_BORDER[s.sport],color:'#fff',padding:'1px 3px',borderRadius:2,fontWeight:700 }}>FAIT</span>}
+                    {s.status!=='done' && isSessionModified(s) && <span title="Modifié par toi" style={{ position:'absolute',top:3,right:3,width:5,height:5,borderRadius:'50%',background:'#f97316',flexShrink:0 }} />}
                     {s.planVariant && <span style={{ position:'absolute',top:2,left:2,fontSize:7,fontWeight:800,color:s.planVariant==='A'?'#00c8e0':'#a78bfa' }}>{s.planVariant}</span>}
                     <div style={{ display:'flex',alignItems:'center',gap:3,paddingLeft:8 }}>
                       <SportBadge sport={s.sport} size="xs"/>
@@ -2009,12 +2145,13 @@ function TrainingTab() {
         <div style={{ background:'var(--bg-card)',border:'1px solid var(--border)',borderRadius:14,padding:16,boxShadow:'var(--shadow-card)' }}>
           <p style={{ fontSize:10,fontWeight:600,textTransform:'uppercase' as const,letterSpacing:'0.07em',color:'var(--text-dim)',margin:'0 0 10px' }}>Aujourd'hui — {week[todayIdx]?.day} {week[todayIdx]?.date}</p>
           {todaySessions.map(s=>(
-            <div key={s.id} onClick={()=>setDetailModal(s)} style={{ display:'flex',alignItems:'center',gap:10,padding:'10px 13px',borderRadius:10,background:SPORT_BG[s.sport],borderLeft:`3px solid ${SPORT_BORDER[s.sport]}`,cursor:'pointer',marginBottom:7 }}>
+            <div key={s.id} onClick={()=>setDetailModal(s)} style={{ display:'flex',alignItems:'center',gap:10,padding:'10px 13px',borderRadius:10,background:SPORT_BG[s.sport],borderLeft:`3px solid ${SPORT_BORDER[s.sport]}`,cursor:'pointer',marginBottom:7,position:'relative' }}>
               <SportBadge sport={s.sport} size="sm"/>
               <div style={{ flex:1 }}>
                 <p style={{ fontFamily:'Syne,sans-serif',fontSize:14,fontWeight:700,margin:0 }}>{s.title}</p>
                 <p style={{ fontSize:11,color:'var(--text-dim)',margin:'2px 0 0' }}>{s.time} · {formatHM(s.durationMin)}{s.tss?` · ${s.tss} TSS`:''}</p>
               </div>
+              {s.status!=='done' && isSessionModified(s) && <span title="Modifié par toi" style={{ width:7,height:7,borderRadius:'50%',background:'#f97316',flexShrink:0 }} />}
               <span style={{ padding:'4px 10px',borderRadius:20,background:s.status==='done'?`${SPORT_BORDER[s.sport]}22`:'var(--bg-card2)',border:`1px solid ${s.status==='done'?SPORT_BORDER[s.sport]:'var(--border)'}`,color:s.status==='done'?SPORT_BORDER[s.sport]:'var(--text-dim)',fontSize:10,fontWeight:600 }}>{s.status==='done'?'FAIT':'À faire'}</span>
             </div>
           ))}
@@ -3146,6 +3283,33 @@ function SessionDetailModal({ session, onClose, onSave, onAutoSave, onValidate, 
           background:'rgba(255,95,95,0.10)', border:'1px solid rgba(255,95,95,0.25)',
           color:'#ff5f5f', fontSize:12, cursor:'pointer', fontWeight:600,
         }}>Supprimer la séance</button>
+        {/* Phase 5 — Reset vers version IA originale */}
+        {session.originalContent && isSessionModified(form) && (
+          <button
+            onClick={() => {
+              const o = session.originalContent!
+              const restored: Session = {
+                ...session,
+                title:       typeof o.titre       === 'string' ? o.titre       : session.title,
+                durationMin: typeof o.duration_min === 'number' ? o.duration_min : session.durationMin,
+                notes:       typeof o.notes       === 'string' ? o.notes       : session.notes,
+                rpe:         typeof o.rpe         === 'number' ? o.rpe         : session.rpe,
+                blocks:      normalizeBlocks((o.blocs as unknown[] | undefined) ?? []),
+              }
+              onSave(restored)
+              onClose()
+            }}
+            title="Revenir à la version générée par le Coach IA"
+            style={{
+              padding:'9px 12px', borderRadius:9,
+              background:'rgba(249,115,22,0.10)', border:'1px solid rgba(249,115,22,0.30)',
+              color:'#f97316', fontSize:11, cursor:'pointer', fontWeight:600,
+              display:'flex', alignItems:'center', gap:4,
+            }}
+          >
+            <span style={{ fontSize:10 }}>↩</span> Réinitialiser
+          </button>
+        )}
         <div style={{ flex:1 }} />
         <span style={{ fontSize:10, color:'var(--text-dim)', fontStyle:'italic' }}>Sauvegarde auto</span>
         <button onClick={onClose} style={{

--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -744,8 +744,9 @@ interface AiPlanWeekMeta {
   theme?: string
   volume_h?: number
   tss_semaine?: number
-  seances?: unknown[]   // semaines S1-S2 : séances détaillées
-  note_coach?: string   // semaines S3+  : résumé coach
+  // Toutes les semaines ont des séances depuis le fix du prompt (blocs uniquement S1-S2)
+  seances?: unknown[]
+  note_coach?: string
 }
 interface AiTrainingPlan {
   id: string
@@ -960,9 +961,38 @@ function exportPlanToPDF(plan: AiTrainingPlan) {
     run:'Course à pied', bike:'Cyclisme', swim:'Natation',
     hyrox:'Hyrox', gym:'Musculation', rowing:'Aviron',
   }
+  const SPORT_COLORS: Record<string, string> = {
+    run:'#f97316', bike:'#3b82f6', swim:'#06b6d4',
+    hyrox:'#ec4899', gym:'#8b5cf6', rowing:'#14b8a6',
+  }
   const INTENS_LABEL_PDF: Record<string, string> = {
     low:'Endurance', moderate:'Tempo / Z3', high:'Intensif / Z4', max:'VO2max / Z5',
   }
+  const DAY_NAMES_PDF = ['Lun','Mar','Mer','Jeu','Ven','Sam','Dim']
+
+  // Formatte durée en hhmm
+  function fmtDurPDF(min: number): string {
+    const h = Math.floor(min / 60), m = min % 60
+    if (h === 0) return `${m}min`
+    return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`
+  }
+
+  // Résolution du nom de sport affiché
+  function sportLabel(raw: string): string {
+    const lower = raw.toLowerCase()
+    const direct = SPORT_NAMES[lower]
+    if (direct) return direct
+    // Recherche par valeur (le coach peut envoyer le nom en français)
+    const found = Object.entries(SPORT_NAMES).find(([, v]) => v.toLowerCase() === lower)
+    return found ? found[1] : raw
+  }
+  function sportColor(raw: string): string {
+    const lower = raw.toLowerCase()
+    if (SPORT_COLORS[lower]) return SPORT_COLORS[lower]
+    const found = Object.entries(SPORT_NAMES).find(([, v]) => v.toLowerCase() === lower)
+    return found ? (SPORT_COLORS[found[0]] ?? '#8b5cf6') : '#8b5cf6'
+  }
+
   const html = `<!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -970,85 +1000,136 @@ function exportPlanToPDF(plan: AiTrainingPlan) {
 <title>${plan.name}</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, system-ui, sans-serif; background: #fff; color: #111; padding: 28px 32px; font-size: 13px; line-height: 1.5; }
-  h1 { font-size: 22px; font-weight: 800; margin-bottom: 4px; }
-  .meta { font-size: 12px; color: #666; margin-bottom: 4px; }
-  .objectif { font-size: 13px; color: #444; margin: 8px 0 16px; padding: 10px 14px; border-left: 3px solid #8b5cf6; background: #f5f3ff; border-radius: 0 8px 8px 0; }
-  .week { margin-bottom: 22px; page-break-inside: avoid; }
-  .week-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; padding: 6px 10px; background: #f3f4f6; border-radius: 6px; display: flex; justify-content: space-between; }
-  .week-note { font-size: 11px; color: #6b7280; font-style: italic; margin-bottom: 8px; padding-left: 4px; }
-  .sessions { display: flex; flex-direction: column; gap: 6px; }
-  .session { padding: 8px 12px; border-left: 3px solid #8b5cf6; border-radius: 0 8px 8px 0; background: #fafafa; }
-  .session-header { display: flex; align-items: center; gap: 8px; }
-  .session-sport { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; background: #8b5cf622; color: #8b5cf6; padding: 2px 6px; border-radius: 99px; flex-shrink: 0; }
-  .session-title { font-weight: 600; font-size: 13px; }
-  .session-meta { font-size: 11px; color: #6b7280; margin-top: 3px; }
-  .session-notes { font-size: 11px; color: #444; margin-top: 4px; font-style: italic; }
-  .blocs { margin-top: 8px; border-top: 1px solid #e5e7eb; padding-top: 6px; }
-  .bloc { font-size: 11px; color: #374151; padding: 2px 0; }
-  .day-badge { font-size: 10px; background: #e5e7eb; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
-  .footer { margin-top: 28px; border-top: 1px solid #e5e7eb; padding-top: 14px; font-size: 10px; color: #9ca3af; }
+  body { font-family: -apple-system, system-ui, sans-serif; background: #fff; color: #111; padding: 24px 30px; font-size: 12px; line-height: 1.5; }
+  h1 { font-size: 20px; font-weight: 800; margin-bottom: 2px; }
+  .plan-meta { font-size: 11px; color: #6b7280; margin-bottom: 4px; }
+  .objectif { font-size: 12px; color: #374151; margin: 8px 0 16px; padding: 8px 12px; border-left: 3px solid #8b5cf6; background: #f5f3ff; border-radius: 0 6px 6px 0; }
+  .week { margin-bottom: 18px; break-inside: avoid; }
+  .week-header { display: flex; align-items: baseline; gap: 10px; padding: 5px 10px; background: #f1f5f9; border-radius: 6px; margin-bottom: 4px; }
+  .week-num { font-size: 13px; font-weight: 800; color: #1e293b; }
+  .week-type { font-size: 10px; font-weight: 600; color: #8b5cf6; text-transform: uppercase; letter-spacing: 0.06em; }
+  .week-stats { margin-left: auto; display: flex; gap: 12px; font-size: 10px; color: #6b7280; font-variant-numeric: tabular-nums; }
+  .week-stats strong { color: #374151; }
+  .week-theme { font-size: 11px; color: #475569; font-style: italic; padding: 0 2px 4px; }
+  .week-coach { font-size: 11px; color: #6b7280; padding: 3px 10px 6px; border-left: 2px solid #e2e8f0; margin: 0 0 6px 4px; }
+  .sessions { display: flex; flex-direction: column; gap: 4px; }
+  .session { padding: 6px 10px; border-left: 3px solid #8b5cf6; background: #fafafa; border-radius: 0 5px 5px 0; }
+  .session-header { display: flex; align-items: center; gap: 6px; }
+  .sport-badge { font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; padding: 1px 5px; border-radius: 99px; flex-shrink: 0; }
+  .day-badge { font-size: 9px; background: #e2e8f0; color: #475569; padding: 1px 5px; border-radius: 3px; flex-shrink: 0; font-variant-numeric: tabular-nums; }
+  .session-title { font-weight: 600; font-size: 12px; flex: 1; }
+  .session-meta { font-size: 10px; color: #6b7280; margin-top: 2px; display: flex; gap: 10px; flex-wrap: wrap; }
+  .session-notes { font-size: 10px; color: #374151; margin-top: 3px; font-style: italic; }
+  .blocs { margin-top: 5px; padding-top: 5px; border-top: 1px solid #e2e8f0; display: flex; flex-direction: column; gap: 2px; }
+  .bloc { font-size: 10px; color: #374151; display: flex; gap: 6px; align-items: baseline; }
+  .bloc-name { font-weight: 600; }
+  .bloc-detail { color: #6b7280; }
+  .bloc-zone { display: inline-block; width: 14px; height: 8px; border-radius: 2px; vertical-align: middle; margin-right: 2px; }
+  .footer { margin-top: 24px; padding-top: 10px; border-top: 1px solid #e2e8f0; font-size: 9px; color: #9ca3af; display: flex; justify-content: space-between; }
   @media print {
-    body { padding: 16px 20px; }
-    .week { page-break-inside: avoid; }
-    @page { margin: 1.2cm; }
+    body { padding: 12px 16px; font-size: 11px; }
+    .week { break-inside: avoid; }
+    @page { margin: 1cm; size: A4; }
   }
 </style>
 </head>
 <body>
-<h1>${plan.name}</h1>
-<p class="meta">Plan ${plan.duree_semaines} semaines · Du ${plan.start_date} au ${plan.end_date} · Sports : ${plan.sports.map(s => SPORT_NAMES[s] ?? s).join(', ')}</p>
+
+<div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:12px">
+  <div>
+    <h1>${plan.name}</h1>
+    <p class="plan-meta">
+      ${plan.duree_semaines} semaines &nbsp;·&nbsp; ${plan.start_date} → ${plan.end_date}
+      &nbsp;·&nbsp; Sports : ${plan.sports.map(s => sportLabel(s)).join(', ')}
+    </p>
+  </div>
+  <div style="text-align:right;font-size:10px;color:#9ca3af;white-space:nowrap">
+    Plan THW Coach IA<br>
+    ${new Date().toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}
+  </div>
+</div>
+
 ${plan.objectif_principal ? `<div class="objectif">${plan.objectif_principal}</div>` : ''}
+
 ${semaines.map((sem) => {
   const seances = (Array.isArray(sem.seances) ? sem.seances : []) as Record<string, unknown>[]
+  const volumeH = typeof sem.volume_h === 'number' ? sem.volume_h : null
+  const tssSem  = typeof sem.tss_semaine === 'number' ? sem.tss_semaine : null
+  const ZONE_PDF_COLORS = ['#9ca3af','#22c55e','#eab308','#f97316','#ef4444']
+
   return `<div class="week">
-  <div class="week-title"><span>Semaine ${sem.numero}</span><span style="font-weight:400;color:#6b7280">${seances.length} séance${seances.length !== 1 ? 's' : ''}</span></div>
-  ${sem.note_coach ? `<div class="week-note">${sem.note_coach}</div>` : ''}
+  <div class="week-header">
+    <span class="week-num">Semaine ${sem.numero}</span>
+    ${sem.type ? `<span class="week-type">${sem.type}</span>` : ''}
+    <span class="week-stats">
+      ${volumeH !== null ? `<span><strong>${volumeH}h</strong> vol.</span>` : ''}
+      ${tssSem !== null ? `<span><strong>${tssSem}</strong> TSS</span>` : ''}
+      ${seances.length > 0 ? `<span><strong>${seances.length}</strong> séance${seances.length > 1 ? 's' : ''}</span>` : ''}
+    </span>
+  </div>
+  ${sem.theme ? `<p class="week-theme">${sem.theme}</p>` : ''}
+  ${sem.note_coach ? `<p class="week-coach">${sem.note_coach}</p>` : ''}
+  ${seances.length === 0 ? '<p style="font-size:10px;color:#9ca3af;padding:4px 10px">Semaine de repos</p>' : `
   <div class="sessions">
   ${seances.map((s: Record<string, unknown>) => {
-    const sport = typeof s.sport === 'string' ? s.sport : ''
-    const sportNorm = Object.entries(SPORT_NAMES).find(([,v]) => v.toLowerCase() === sport.toLowerCase())?.[0] ?? sport.toLowerCase()
-    const sportLabel = SPORT_NAMES[sportNorm] ?? sport
-    const titre = typeof s.titre === 'string' ? s.titre : ''
-    const jour = typeof s.jour === 'number' ? s.jour : null
-    const dureMin = typeof s.duree_min === 'number' ? s.duree_min : null
-    const tss = typeof s.tss === 'number' ? s.tss : null
-    const intensite = typeof s.intensite === 'string' ? s.intensite : null
-    const notes = typeof s.notes === 'string' ? s.notes : null
-    const blocs = Array.isArray(s.blocs) ? s.blocs as Record<string, unknown>[] : []
-    const DAY_NAMES_PDF = ['Lun','Mar','Mer','Jeu','Ven','Sam','Dim']
-    const dayLabel = jour !== null ? `Jour ${jour} — ${DAY_NAMES_PDF[jour] ?? ''}` : ''
-    const metaParts = [
-      dureMin ? `${Math.floor(dureMin / 60) > 0 ? Math.floor(dureMin / 60) + 'h' : ''}${dureMin % 60 > 0 ? (dureMin % 60) + 'min' : ''}` : null,
-      tss ? `${tss} TSS` : null,
-      intensite ? (INTENS_LABEL_PDF[intensite] ?? intensite) : null,
-    ].filter(Boolean)
-    return `<div class="session">
+    const rawSport   = typeof s.sport    === 'string' ? s.sport    : ''
+    const titre      = typeof s.titre    === 'string' ? s.titre    : ''
+    const jour       = typeof s.jour     === 'number' ? s.jour     : null
+    const dureMin    = typeof s.duree_min === 'number' ? s.duree_min : null
+    const heure      = typeof s.heure    === 'string' ? s.heure    : null
+    const tss        = typeof s.tss      === 'number' ? s.tss      : null
+    const intensite  = typeof s.intensite === 'string' ? s.intensite : null
+    const notes      = typeof s.notes    === 'string' ? s.notes    : null
+    const rpe        = typeof s.rpe      === 'number' ? s.rpe      : null
+    const blocs      = Array.isArray(s.blocs) ? s.blocs as Record<string, unknown>[] : []
+    const col        = sportColor(rawSport)
+    const dayLabel   = jour !== null ? `${DAY_NAMES_PDF[jour] ?? 'J' + jour}` : ''
+
+    return `<div class="session" style="border-left-color:${col}">
     <div class="session-header">
       ${dayLabel ? `<span class="day-badge">${dayLabel}</span>` : ''}
-      <span class="session-sport">${sportLabel}</span>
+      ${heure ? `<span style="font-size:9px;color:#6b7280;font-variant-numeric:tabular-nums">${heure}</span>` : ''}
+      <span class="sport-badge" style="background:${col}22;color:${col}">${sportLabel(rawSport)}</span>
       <span class="session-title">${titre}</span>
     </div>
-    ${metaParts.length ? `<div class="session-meta">${metaParts.join(' · ')}</div>` : ''}
-    ${notes ? `<div class="session-notes">${notes}</div>` : ''}
+    <div class="session-meta">
+      ${dureMin !== null ? `<span>⏱ ${fmtDurPDF(dureMin)}</span>` : ''}
+      ${tss !== null ? `<span>${tss} TSS</span>` : ''}
+      ${intensite ? `<span>${INTENS_LABEL_PDF[intensite] ?? intensite}</span>` : ''}
+      ${rpe !== null ? `<span>RPE ${rpe}/10</span>` : ''}
+    </div>
+    ${notes ? `<p class="session-notes">${notes}</p>` : ''}
     ${blocs.length > 0 ? `<div class="blocs">${blocs.map((b: Record<string, unknown>) => {
-      const nom = typeof b.nom === 'string' ? b.nom : ''
-      const duree = typeof b.duree_min === 'number' ? b.duree_min : null
-      const zone = typeof b.zone === 'number' ? b.zone : null
-      const reps = typeof b.repetitions === 'number' && b.repetitions > 1 ? b.repetitions : null
-      const parts = [
-        nom,
-        reps ? `${reps}×${duree}min` : (duree ? `${duree}min` : null),
-        zone ? `Z${zone}` : null,
-      ].filter(Boolean)
-      return `<div class="bloc">· ${parts.join(' — ')}</div>`
+      const bNom   = typeof b.nom        === 'string' ? b.nom        : ''
+      const bDur   = typeof b.duree_min  === 'number' ? b.duree_min  : null
+      const bZone  = typeof b.zone       === 'number' ? b.zone       : null
+      const bReps  = typeof b.repetitions === 'number' && b.repetitions > 1 ? b.repetitions : null
+      const bWatts = typeof b.watts      === 'number' ? b.watts      : null
+      const bAllure= typeof b.allure     === 'string' ? b.allure     : null
+      const bConsigne = typeof b.consigne === 'string' ? b.consigne  : null
+      const bZoneColor = bZone ? (ZONE_PDF_COLORS[bZone - 1] ?? '#9ca3af') : '#9ca3af'
+      const detail = [
+        bReps ? `${bReps}×${bDur}min` : (bDur ? `${fmtDurPDF(bDur)}` : null),
+        bZone ? `Z${bZone}` : null,
+        bWatts ? `${bWatts}W` : (bAllure ?? null),
+      ].filter(Boolean).join(' · ')
+      return `<div class="bloc">
+        <span class="bloc-zone" style="background:${bZoneColor}"></span>
+        <span class="bloc-name">${bNom}</span>
+        ${detail ? `<span class="bloc-detail">${detail}</span>` : ''}
+        ${bConsigne ? `<span class="bloc-detail">— ${bConsigne}</span>` : ''}
+      </div>`
     }).join('')}</div>` : ''}
     </div>`
   }).join('')}
-  </div>
+  </div>`}
 </div>`
 }).join('')}
-<div class="footer">Exporté depuis THW Coaching · Plan généré par le Coach IA · ${new Date().toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })}</div>
+
+<div class="footer">
+  <span>Généré par THW Coach IA · ${plan.name}</span>
+  <span>${plan.start_date} → ${plan.end_date} · ${plan.duree_semaines} semaines</span>
+</div>
 </body>
 </html>`
 

--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -1069,8 +1069,7 @@ ${semaines.map((sem) => {
   </div>
   ${sem.theme ? `<p class="week-theme">${sem.theme}</p>` : ''}
   ${sem.note_coach ? `<p class="week-coach">${sem.note_coach}</p>` : ''}
-  ${seances.length === 0 ? '<p style="font-size:10px;color:#9ca3af;padding:4px 10px">Semaine de repos</p>' : `
-  <div class="sessions">
+  ${seances.length > 0 ? `<div class="sessions">
   ${seances.map((s: Record<string, unknown>) => {
     const rawSport   = typeof s.sport    === 'string' ? s.sport    : ''
     const titre      = typeof s.titre    === 'string' ? s.titre    : ''
@@ -1122,7 +1121,7 @@ ${semaines.map((sem) => {
     }).join('')}</div>` : ''}
     </div>`
   }).join('')}
-  </div>`}
+  </div>` : ''}
 </div>`
 }).join('')}
 

--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -1087,7 +1087,23 @@ function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <p style={{ fontSize: 10, fontWeight: 700, color: '#8b5cf6', margin: 0, letterSpacing: '0.12em', textTransform: 'uppercase' as const }}>Plan en cours</p>
-          <p style={{ fontSize: 17, fontWeight: 800, color: 'var(--text)', margin: '2px 0 4px', fontFamily: 'Syne,sans-serif', lineHeight: 1.2 }}>{plan.name}</p>
+          {/* Titre + bouton PDF côte à côte */}
+          <div style={{ display:'flex', alignItems:'center', gap:8, margin:'2px 0 4px' }}>
+            <p style={{ fontSize: 17, fontWeight: 800, color: 'var(--text)', margin: 0, fontFamily: 'Syne,sans-serif', lineHeight: 1.2, flex: 1, minWidth: 0 }}>{plan.name}</p>
+            <button
+              onClick={() => exportPlanToPDF(plan)}
+              title="Exporter le plan complet en PDF"
+              style={{
+                padding:'4px 10px', borderRadius:7,
+                background:'rgba(139,92,246,0.10)', border:'1px solid rgba(139,92,246,0.25)',
+                color:'#8b5cf6', fontSize:10, fontWeight:600, cursor:'pointer',
+                display:'flex', alignItems:'center', gap:4, flexShrink:0,
+                whiteSpace:'nowrap' as const,
+              }}
+            >
+              ↓ PDF
+            </button>
+          </div>
           {plan.objectif_principal && (
             <p style={{ fontSize: 12, color: 'var(--text-mid)', margin: '0 0 6px', lineHeight: 1.45 }}>{plan.objectif_principal}</p>
           )}
@@ -1097,21 +1113,7 @@ function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
               <div style={{ width: `${(currentWeekNum / plan.duree_semaines) * 100}%`, height: '100%', background: 'linear-gradient(90deg,#8b5cf6,#5b6fff)', transition: 'width 0.3s ease' }} />
             </div>
           </div>
-          <div style={{ display:'flex', alignItems:'center', gap:10, marginTop:4 }}>
-            <p style={{ fontSize: 10, color: 'var(--text-dim)', margin: 0 }}>Du {fmtFrenchDate(plan.start_date)} au {fmtFrenchDate(plan.end_date)}</p>
-            <button
-              onClick={() => exportPlanToPDF(plan)}
-              title="Exporter le plan complet en PDF"
-              style={{
-                padding:'2px 8px', borderRadius:6,
-                background:'transparent', border:'1px solid var(--border)',
-                color:'var(--text-dim)', fontSize:10, cursor:'pointer',
-                display:'flex', alignItems:'center', gap:3, flexShrink:0,
-              }}
-            >
-              <span>↓</span> PDF
-            </button>
-          </div>
+          <p style={{ fontSize: 10, color: 'var(--text-dim)', margin: '4px 0 0' }}>Du {fmtFrenchDate(plan.start_date)} au {fmtFrenchDate(plan.end_date)}</p>
         </div>
 
         {/* ── Prochain objectif ── */}
@@ -1457,13 +1459,13 @@ function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
           .filter(e => e.mins > 0)
         const zoneArcs = buildArcs(zoneEntries)
 
-        // ── DONUT 2 : Sports (plan complet, semaines S1-S2) ──────
-        const allSeances = (plan.ai_context?.program?.semaines ?? [])
-          .flatMap(w => (w.seances as { sport?: string; duree_min?: number }[] | undefined) ?? [])
+        // ── DONUT 2 : Sports (plan complet — toutes les planned_sessions du plan) ──────
+        // On utilise la prop `sessions` (AiPlanSessionAgg[] depuis la table planned_sessions)
+        // qui couvre TOUTES les semaines du plan, pas seulement S1-S2 comme ai_context.
         const sportMap: Record<string, number> = {}
-        for (const s of allSeances) {
+        for (const s of sessions) {
           if (!s.sport) continue
-          sportMap[s.sport] = (sportMap[s.sport] ?? 0) + (s.duree_min ?? 0)
+          sportMap[s.sport] = (sportMap[s.sport] ?? 0) + (s.duration_min ?? 0)
         }
         const totalSportMins = Object.values(sportMap).reduce((a, b) => a + b, 0)
         const sportEntries = Object.entries(sportMap)
@@ -1471,10 +1473,10 @@ function PlanHeaderAndGraphics({ plan, sessions, currentWeekStart, nextRace }: {
           .sort((a, b) => b.mins - a.mins)
         const sportArcs = buildArcs(sportEntries)
 
-        // ── DONUT 3 : Répartition charge plan (all seances) ──────
+        // ── DONUT 3 : Répartition charge plan (toutes les planned_sessions) ──────
         const intensMap: Record<string, number> = {}
-        for (const s of allSeances) {
-          const key = (s as { intensite?: string }).intensite ?? 'low'
+        for (const s of sessions) {
+          const key = s.intensity ?? 'low'
           intensMap[key] = (intensMap[key] ?? 0) + 1
         }
         const totalSessions = Object.values(intensMap).reduce((a, b) => a + b, 0)
@@ -3283,33 +3285,39 @@ function SessionDetailModal({ session, onClose, onSave, onAutoSave, onValidate, 
           background:'rgba(255,95,95,0.10)', border:'1px solid rgba(255,95,95,0.25)',
           color:'#ff5f5f', fontSize:12, cursor:'pointer', fontWeight:600,
         }}>Supprimer la séance</button>
-        {/* Phase 5 — Reset vers version IA originale */}
-        {session.originalContent && isSessionModified(form) && (
-          <button
-            onClick={() => {
-              const o = session.originalContent!
-              const restored: Session = {
-                ...session,
-                title:       typeof o.titre       === 'string' ? o.titre       : session.title,
-                durationMin: typeof o.duration_min === 'number' ? o.duration_min : session.durationMin,
-                notes:       typeof o.notes       === 'string' ? o.notes       : session.notes,
-                rpe:         typeof o.rpe         === 'number' ? o.rpe         : session.rpe,
-                blocks:      normalizeBlocks((o.blocs as unknown[] | undefined) ?? []),
-              }
-              onSave(restored)
-              onClose()
-            }}
-            title="Revenir à la version générée par le Coach IA"
-            style={{
-              padding:'9px 12px', borderRadius:9,
-              background:'rgba(249,115,22,0.10)', border:'1px solid rgba(249,115,22,0.30)',
-              color:'#f97316', fontSize:11, cursor:'pointer', fontWeight:600,
-              display:'flex', alignItems:'center', gap:4,
-            }}
-          >
-            <span style={{ fontSize:10 }}>↩</span> Réinitialiser
-          </button>
-        )}
+        {/* Phase 5 — Reset vers version IA originale (visible dès qu'il y a un original) */}
+        {session.originalContent && (() => {
+          const modified = isSessionModified(form)
+          return (
+            <button
+              onClick={() => {
+                if (!modified) return
+                const o = session.originalContent!
+                const restored: Session = {
+                  ...session,
+                  title:       typeof o.titre       === 'string' ? o.titre       : session.title,
+                  durationMin: typeof o.duration_min === 'number' ? o.duration_min : session.durationMin,
+                  notes:       typeof o.notes       === 'string' ? o.notes       : session.notes,
+                  rpe:         typeof o.rpe         === 'number' ? o.rpe         : session.rpe,
+                  blocks:      normalizeBlocks((o.blocs as unknown[] | undefined) ?? []),
+                }
+                onSave(restored)
+                onClose()
+              }}
+              title={modified ? 'Revenir à la version générée par le Coach IA' : 'Séance non modifiée — identique à la version IA'}
+              style={{
+                padding:'9px 12px', borderRadius:9,
+                background: modified ? 'rgba(249,115,22,0.10)' : 'transparent',
+                border: modified ? '1px solid rgba(249,115,22,0.30)' : '1px solid var(--border)',
+                color: modified ? '#f97316' : 'var(--text-dim)',
+                fontSize:11, cursor: modified ? 'pointer' : 'default', fontWeight:600,
+                display:'flex', alignItems:'center', gap:4, opacity: modified ? 1 : 0.5,
+              }}
+            >
+              <span style={{ fontSize:10 }}>↩</span> {modified ? 'Réinitialiser' : 'Original IA'}
+            </button>
+          )
+        })()}
         <div style={{ flex:1 }} />
         <span style={{ fontSize:10, color:'var(--text-dim)', fontStyle:'italic' }}>Sauvegarde auto</span>
         <button onClick={onClose} style={{

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -5307,15 +5307,24 @@ export default function AIPanel({
 
   // ── Phase 4 : initialise la conversation liée au plan ──────────
   // Quand le panel s'ouvre avec un planId, trouve ou crée une conv
-  // taggée [PLAN:id] pour reprendre la mémoire du plan en continu.
-  const planConvInitRef = useRef<string | null>(null)
+  // taggée [PLAN:id] et l'active automatiquement.
+  // Le ref sert à éviter de créer la conv deux fois si les deps
+  // se re-déclenchent sans que le panel ait été fermé entre-temps.
+  const planConvCreatedRef = useRef<string | null>(null)
   useEffect(() => {
     if (!open || !planId || !mounted) return
-    if (planConvInitRef.current === planId) return   // déjà initialisé
-    planConvInitRef.current = planId
 
+    // Cherche une conv existante pour ce plan (localStorage ou state)
     const existing = convs.find(c => c.title.startsWith(`[PLAN:${planId}]`))
-    if (existing) { setActiveId(existing.id); return }
+    if (existing) {
+      // Toujours re-sélectionner la conv du plan à l'ouverture
+      setActiveId(existing.id)
+      return
+    }
+
+    // Évite de créer la conv deux fois en cas de double-déclenchement
+    if (planConvCreatedRef.current === planId) return
+    planConvCreatedRef.current = planId
 
     // Nouvelle conv — welcome message du coach
     const welcomeText = `Je suis ton Coach IA. J'ai l'intégralité de ton plan **${planName ?? 'en cours'}** en mémoire — objectif, périodisation, chaque semaine et chaque séance. Pose-moi toutes tes questions ou demande des ajustements : je réponds directement en me basant sur ton programme.`
@@ -5328,7 +5337,8 @@ export default function AIPanel({
     }
     setConvs(prev => [planConv, ...prev].slice(0, MAX_CONVS))
     setActiveId(newId)
-  // convs est intentionnellement omis — on lit sa valeur courante via la ref
+  // convs est intentionnellement omis des deps — on veut déclencher sur open/planId/mounted,
+  // pas à chaque message envoyé. La valeur courante de convs est lue dans la closure.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, planId, mounted, planName])
 

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -6155,8 +6155,8 @@ export default function AIPanel({
                         return (
                           <div style={{
                             flex: 1, minWidth: 0,
-                            background: '#161B24',
-                            border: '1px solid #1E2533',
+                            background: 'var(--ai-bg2)',
+                            border: '1px solid var(--ai-border)',
                             borderRadius: '4px 18px 18px 18px',
                             padding: '10px 14px 10px 14px',
                             animation: 'ai_msg_in 0.15s ease both',
@@ -6189,8 +6189,8 @@ export default function AIPanel({
                     </div>
                     <div style={{
                       padding: '8px 14px',
-                      background: '#161B24',
-                      border: '1px solid #1E2533',
+                      background: 'var(--ai-bg2)',
+                      border: '1px solid var(--ai-border)',
                       borderRadius: '4px 18px 18px 18px',
                       display: 'flex', alignItems: 'center',
                     }}>


### PR DESCRIPTION
## Resume

5 commits de cette session sur /planning.

### Phase 5 (3ea148e)
- Badge modifie : point orange sur seances modifiees vs original IA
- Reinitialiser : footer modal seance, restaure valeurs IA
- Export PDF : cote titre du plan, complet par semaine

### 3 bug fixes (c84796d)
- AIPanel vide sur Mon plan : fond noir corrige
- Donuts vides : migres vers sessions prop (toutes semaines)
- Boutons Phase 5 repositionnes

### Prompt generation + PDF (1f257ee)
- seances[] pour toutes les semaines, blocs[] S1-S2 uniquement

### Fix PDF Semaine de repos (ab87a14)
- Texte hardcode supprime, note_coach porte le message

### Fix AIPanel fond noir (9e2d9d2)
- background:#161B24 -> var(--ai-bg2), border:#1E2533 -> var(--ai-border)

## Test plan
- [ ] Generer plan IA -> seances sur toutes les semaines
- [ ] Modifier seance -> badge orange
- [ ] Reinitialiser -> valeurs IA restaurees
- [ ] PDF -> header, note_coach, seances, blocs S1-S2
- [ ] Drawer Coach IA pas de fond noir en light mode
- [ ] Donuts affichent des donnees

 Generated with Claude Code