### PR TITLE
feat(ai): refonte sidebar IA façon Claude — fond sombre + logo officiel

### DIFF
--- a/PROMPT_IA_SIDEBAR_V2.md
+++ b/PROMPT_IA_SIDEBAR_V2.md
@@ -1,0 +1,339 @@
+# PROMPT IA SIDEBAR V2
+
+## PROBLÈMES À CORRIGER EN PRIORITÉ
+
+### Problème 1 — Logo incorrect
+Chercher dans TOUT le projet le composant du logo shuriken THW.
+Il est probablement dans :
+- `/components/ui/Logo.tsx`
+- `/components/Logo.tsx`
+- `/public/` (SVG ou PNG)
+- Dans le header de l'app principale
+
+Utiliser CE composant existant partout dans l'interface IA.
+Ne jamais dessiner un nouveau SVG étoile ou shuriken —
+utiliser uniquement le logo officiel déjà dans le projet.
+
+### Problème 2 — Structure sidebar à refaire entièrement
+Ignorer tout ce qui a été fait sur la sidebar précédemment.
+Repartir de zéro en suivant exactement ce prompt.
+
+---
+
+## SIDEBAR : STRUCTURE EXACTE
+
+S'inspirer pixel par pixel de la sidebar Claude (image de référence).
+Fond sombre : `#1A1A1A`. Texte blanc.
+
+### ZONE HAUTE — Nom de l'app
+
+```tsx
+<div className="px-5 pt-5 pb-4">
+  <div className="flex items-center justify-between">
+
+    {/* Nom de l'app — même style typographique que "Claude" */}
+    <h1 className="text-[28px] font-semibold tracking-tight
+                   text-white leading-none">
+      Hybrid
+    </h1>
+
+    {/* Avatar utilisateur — cercle avec initiale */}
+    <div className="w-9 h-9 rounded-full bg-[#3A3A3A]
+                    flex items-center justify-center
+                    text-sm font-medium text-white
+                    cursor-pointer hover:bg-[#444] transition-colors">
+      {userInitial}  {/* ex: "A" pour Alex */}
+    </div>
+  </div>
+</div>
+```
+
+### ZONE NAVIGATION — 3 items
+
+Même structure que Claude : icône + label, spacing généreux.
+Pas de border. Hover = léger fond arrondi.
+
+```tsx
+<nav className="px-3 pb-4">
+
+  {/* PROJETS */}
+  <NavItem
+    icon={<ProjectsIcon />}   // SVG dossier empilé — même icône que Claude
+    label="Projets"
+    onClick={() => setView('projects')}
+    active={view === 'projects'}
+  />
+
+  {/* TRAINING — agent Hybrid Training */}
+  <NavItem
+    icon={<LogoShuriken size={18} />}  // logo THW existant
+    label="Training"
+    onClick={() => setView('training')}
+    active={view === 'training'}
+  />
+
+  {/* NETWORKS — agent Networks */}
+  <NavItem
+    icon={<NetworksIcon />}   // SVG réseau/connexion simple
+    label="Networks"
+    onClick={() => setView('networks')}
+    active={view === 'networks'}
+  />
+</nav>
+```
+
+Composant NavItem :
+
+```tsx
+function NavItem({ icon, label, onClick, active }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        w-full flex items-center gap-3 px-3 py-2.5
+        rounded-xl text-base font-medium
+        transition-colors duration-100
+        ${active
+          ? 'bg-white/10 text-white'
+          : 'text-white/70 hover:text-white hover:bg-white/5'
+        }
+      `}
+    >
+      <span className="w-5 flex items-center justify-center opacity-70">
+        {icon}
+      </span>
+      {label}
+    </button>
+  )
+}
+```
+
+### SÉPARATEUR + LABEL "Récents"
+
+```tsx
+<div className="px-5 pt-2 pb-1">
+  <p className="text-xs font-medium text-white/40 uppercase tracking-wider">
+    Récents
+  </p>
+</div>
+```
+
+### LISTE DES CONVERSATIONS
+
+Filtrée selon la vue active (Training → conversations de l'agent Training,
+Networks → conversations Networks, Projets → projets).
+
+```tsx
+<div className="flex-1 overflow-y-auto px-2">
+  {conversations.map(conv => (
+    <button
+      key={conv.id}
+      onClick={() => openConversation(conv.id)}
+      className={`
+        w-full text-left px-3 py-2 rounded-xl
+        transition-colors duration-100
+        ${activeConvId === conv.id
+          ? 'bg-white/10'
+          : 'hover:bg-white/5'
+        }
+      `}
+    >
+      <p className="text-sm text-white/90 truncate font-medium leading-snug">
+        {conv.title ?? 'Nouvelle discussion'}
+      </p>
+      <p className="text-xs text-white/40 mt-0.5">
+        {formatRelativeDate(conv.updated_at)}
+      </p>
+    </button>
+  ))}
+</div>
+```
+
+### BOUTON "NOUVELLE CONVERSATION" — en bas
+
+C'est l'élément le plus important visuellement.
+Exactement comme Claude : pill blanche, "+" à gauche, texte centré.
+
+```tsx
+<div className="px-4 pb-6 pt-3">
+  <button
+    onClick={createNewConversation}
+    className="
+      w-full h-12
+      bg-white text-[#1A1A1A]
+      rounded-full
+      flex items-center justify-center gap-2
+      text-sm font-semibold
+      shadow-lg
+      hover:bg-white/90
+      active:scale-[0.98]
+      transition-all duration-150
+    "
+  >
+    {/* Icône + */}
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M8 2v12M2 8h12" stroke="currentColor"
+            strokeWidth="2" strokeLinecap="round"/>
+    </svg>
+    Nouvelle conversation
+  </button>
+</div>
+```
+
+---
+
+## HEADER DE LA PAGE (ligne du haut quand sidebar fermée)
+
+Sur mobile, quand la sidebar est fermée :
+
+```tsx
+<header className="h-12 flex items-center px-4 relative">
+
+  {/* Hamburger gauche */}
+  <button
+    onClick={() => setSidebarOpen(true)}
+    className="w-8 h-8 rounded-lg flex items-center justify-center
+               text-[#8C8C8C] hover:bg-black/5 transition-colors"
+  >
+    <svg width="18" height="14" viewBox="0 0 18 14" fill="none">
+      <path d="M0 1h18M0 7h18M0 13h18"
+            stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  </button>
+
+  {/* Nom agent centré — avec le BON logo */}
+  <div className="absolute left-1/2 -translate-x-1/2
+                  flex items-center gap-2">
+    <LogoShuriken size={16} color={agentColor} />
+    <span className="text-sm font-semibold text-[#0A0A0A] dark:text-white">
+      {currentAgentName}
+      {/* "Training" ou "Networks" selon l'agent actif */}
+    </span>
+  </div>
+
+  {/* Actions droite */}
+  <div className="ml-auto flex items-center gap-0.5">
+    {/* + nouvelle conversation */}
+    <button className="w-8 h-8 rounded-lg flex items-center justify-center
+                       text-[#8C8C8C] hover:bg-black/5 transition-colors">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M8 2v12M2 8h12" stroke="currentColor"
+              strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    </button>
+    {/* expand */}
+    <button className="w-8 h-8 rounded-lg flex items-center justify-center
+                       text-[#8C8C8C] hover:bg-black/5 transition-colors">
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <path d="M1 5V1h4M9 1h4v4M1 9v4h4M13 9v4H9"
+              stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+      </svg>
+    </button>
+    {/* fermer */}
+    <button className="w-8 h-8 rounded-lg flex items-center justify-center
+                       text-[#8C8C8C] hover:bg-black/5 transition-colors">
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <path d="M1 1l12 12M13 1L1 13" stroke="currentColor"
+              strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    </button>
+  </div>
+</header>
+```
+
+---
+
+## SECTION "PROJETS" (vue quand on clique Projets)
+
+Les Projets dans Claude = collections de conversations avec contexte partagé.
+Dans THW, un Projet = un plan entraînement ou nutritionnel créé par l'IA,
+avec toutes les conversations liées à ce plan.
+
+Fetch :
+
+```ts
+const { data: projects } = await supabase
+  .from('ai_conversations')
+  .select('id, title, agent, created_at')
+  .eq('user_id', session.user.id)
+  .eq('is_project', true)  // ou un champ équivalent
+  .order('created_at', { ascending: false })
+```
+
+Si la table n'a pas de champ `is_project` : ajouter la migration.
+
+```sql
+ALTER TABLE ai_conversations
+  ADD COLUMN IF NOT EXISTS is_project boolean default false,
+  ADD COLUMN IF NOT EXISTS project_name text;
+```
+
+Affichage dans la sidebar quand view === 'projects' :
+Même style que les conversations mais avec une petite icône dossier
+devant chaque item.
+
+---
+
+## ANIMATIONS SIDEBAR MOBILE
+
+```css
+/* Entrée */
+@keyframes sidebar-slide-in {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
+}
+
+/* Sortie */
+@keyframes sidebar-slide-out {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-100%); }
+}
+
+.sidebar-open  { animation: sidebar-slide-in  240ms cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+.sidebar-close { animation: sidebar-slide-out 200ms cubic-bezier(0.4, 0, 1, 1) forwards; }
+```
+
+Backdrop : `fixed inset-0 bg-black/30 backdrop-blur-[2px] z-40`
+Fade-in 200ms / Fade-out 200ms simultanément à la sidebar.
+
+---
+
+## ÉCRAN VIDE (aucune conversation)
+
+```tsx
+<div className="flex-1 flex flex-col items-center justify-center gap-3">
+  {/* Logo THW officiel — composant existant, taille 52px */}
+  <LogoShuriken size={52} color={agentColor} />
+
+  <div className="text-center">
+    <h2 className="text-xl font-semibold text-[#0A0A0A] dark:text-white">
+      {greeting}
+    </h2>
+    <p className="text-sm text-[#8C8C8C] mt-1">
+      Comment puis-je t'aider ?
+    </p>
+  </div>
+</div>
+```
+
+`agentColor` :
+- Training → `#2563EB` (bleu)
+- Networks → `#7C3AED` (violet)
+
+---
+
+## INSTRUCTIONS CRITIQUES POUR CLAUDE CODE
+
+1. AVANT TOUT : chercher le composant Logo/Shuriken dans le projet entier.
+   Commande : `grep -r "shuriken\|Shuriken\|Logo\|logo" --include="*.tsx" src/`
+   Utiliser CE composant. Ne pas en créer un nouveau.
+
+2. Les agents s'appellent "Training" et "Networks" dans l'interface.
+   Pas "Athéna", "Zeus", "Hermès". Ces noms sont des noms internes.
+
+3. Chaque fichier < 200 lignes. Séparer si nécessaire.
+
+4. `npm run build` doit passer avant commit.
+
+5. Ne pas modifier la logique des agents (system prompts, API calls).
+   Uniquement l'interface visuelle.

--- a/src/components/ai/AIHeader.tsx
+++ b/src/components/ai/AIHeader.tsx
@@ -1,13 +1,15 @@
 'use client'
-import { AgentIcon } from './AgentIcon'
-import type { AgentId } from './AgentIcon'
+import { LogoOfficial } from './sidebar/LogoOfficial'
 
 type THWModel = 'hermes' | 'athena' | 'zeus'
 
-const AGENT_NAMES: Record<THWModel, string> = {
-  athena: 'Athena',
-  zeus:   'Zeus',
-  hermes: 'Hermes',
+// Mapping interne → label utilisateur.
+// Les modèles internes (hermes/athena/zeus) sont des routes d'orchestration.
+// L'utilisateur ne voit que "Training" et "Networks".
+const MODEL_TO_AGENT_LABEL: Record<THWModel, string> = {
+  athena: 'Training',
+  zeus:   'Training',
+  hermes: 'Training',
 }
 
 interface Props {
@@ -18,6 +20,7 @@ interface Props {
   onNewConv:            () => void
   onToggleFullscreen:   () => void
   onClose:              () => void
+  agentLabelOverride?:  string  // ex: "Networks" pour le mode Networks
 }
 
 function HeaderBtn({ onClick, title, children }: { onClick: () => void; title: string; children: React.ReactNode }) {
@@ -39,7 +42,12 @@ function HeaderBtn({ onClick, title, children }: { onClick: () => void; title: s
   )
 }
 
-export default function AIHeader({ model, isDesktop, fullscr, onOpenSidebar, onNewConv, onToggleFullscreen, onClose }: Props) {
+export default function AIHeader({
+  model, isDesktop, fullscr,
+  onOpenSidebar, onNewConv, onToggleFullscreen, onClose,
+  agentLabelOverride,
+}: Props) {
+  const agentLabel = agentLabelOverride ?? MODEL_TO_AGENT_LABEL[model]
   return (
     <div style={{
       height: 48, padding: '0 10px',
@@ -56,14 +64,17 @@ export default function AIHeader({ model, isDesktop, fullscr, onOpenSidebar, onN
         </HeaderBtn>
       )}
 
-      {/* Agent name — centered */}
+      {/* Agent name + logo officiel — centered */}
       <div style={{
         position: 'absolute', left: '50%', transform: 'translateX(-50%)',
-        display: 'flex', alignItems: 'center', gap: 7, pointerEvents: 'none',
+        display: 'flex', alignItems: 'center', gap: 8, pointerEvents: 'none',
       }}>
-        <AgentIcon agent={model as AgentId} size={16} />
-        <span style={{ fontSize: 14, fontWeight: 600, color: '#0A0A0A', fontFamily: 'DM Sans,sans-serif' }}>
-          {AGENT_NAMES[model]}
+        <LogoOfficial size={16} alt={agentLabel} />
+        <span style={{
+          fontSize: 14, fontWeight: 600, color: '#0A0A0A',
+          fontFamily: 'DM Sans,sans-serif',
+        }}>
+          {agentLabel}
         </span>
       </div>
 

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -20,6 +20,7 @@ import QuickActionsSheet from './QuickActionsSheet'
 import AIHeader from './AIHeader'
 import { AgentIcon } from './AgentIcon'
 import type { AgentId } from './AgentIcon'
+import { LogoOfficial } from './sidebar/LogoOfficial'
 
 // ── Colonnes activities — source de vérité unique ──────────────
 /** Colonnes SAFE de la table activities — ne JAMAIS ajouter sans vérifier Supabase */
@@ -18887,13 +18888,13 @@ export default function AIPanel({
 
             {/* ── Empty state ── */}
             {showEmpty && !activeFlow && (
-              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, animation: 'ai_slidein 0.25s ease', padding: '40px 20px' }}>
-                <AgentIcon agent={model as AgentId} size={48} />
-                <p style={{ textAlign: 'center', margin: '16px 0 6px', fontSize: 20, fontWeight: 600, color: 'var(--ai-text)', fontFamily: 'DM Sans,sans-serif', lineHeight: 1.3 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, animation: 'ai_slidein 0.25s ease', padding: '40px 20px', gap: 12 }}>
+                <LogoOfficial size={52} />
+                <p style={{ textAlign: 'center', margin: '4px 0 4px', fontSize: 20, fontWeight: 600, color: 'var(--ai-text)', fontFamily: 'DM Sans,sans-serif', lineHeight: 1.3 }}>
                   {mounted ? (getGreeting() === 'matin' ? 'Bonjour, bon matin !' : getGreeting() === 'après-midi' ? 'Bon après-midi !' : 'Bonsoir !') : 'Bonjour !'}
                 </p>
                 <p style={{ textAlign: 'center', fontSize: 13, color: '#8C8C8C', margin: 0 }}>
-                  Comment puis-je t'aider ?
+                  Comment puis-je t&apos;aider ?
                 </p>
               </div>
             )}

--- a/src/components/ai/AISidebar.tsx
+++ b/src/components/ai/AISidebar.tsx
@@ -1,15 +1,16 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
-import { AgentIcon } from './AgentIcon'
-import type { AgentId } from './AgentIcon'
+import { useEffect, useState } from 'react'
+import { LogoOfficial } from './sidebar/LogoOfficial'
+import { NavItem } from './sidebar/NavItem'
+import { ProjectsIcon, NetworksIcon, PlusIcon } from './sidebar/NavIcons'
+import { ConvList, type ConvLike } from './sidebar/ConvList'
 
 type THWModel = 'hermes' | 'athena' | 'zeus'
+type SidebarView = 'projects' | 'training' | 'networks'
 
-interface Conv {
-  id: string
-  title: string
-  updatedAt: number
-  isPinned?: boolean
+interface Conv extends ConvLike {
+  agent?: 'training' | 'networks'
+  isProject?: boolean
 }
 
 interface Props {
@@ -25,218 +26,148 @@ interface Props {
   persistent?:   boolean
 }
 
-const AGENTS: { id: AgentId; name: string }[] = [
-  { id: 'athena', name: 'Athena' },
-  { id: 'zeus',   name: 'Zeus'   },
-  { id: 'hermes', name: 'Hermes' },
-]
+const SIDEBAR_BG = '#1A1A1A'
 
-function fmt(ts: number): string {
-  const d = Date.now() - ts
-  if (d < 60_000)     return 'instant'
-  if (d < 3_600_000)  return `${Math.floor(d / 60_000)}min`
-  if (d < 86_400_000) return `${Math.floor(d / 3_600_000)}h`
-  return new Date(ts).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
+function useUserInitial(): string {
+  const [initial, setInitial] = useState('?')
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { createClient } = await import('@/lib/supabase/client')
+        const sb = createClient()
+        const { data: { user } } = await sb.auth.getUser()
+        const src =
+          (user?.user_metadata as { full_name?: string; name?: string } | undefined)?.full_name ??
+          (user?.user_metadata as { full_name?: string; name?: string } | undefined)?.name ??
+          user?.email ?? ''
+        const ch = (src.trim()[0] ?? '?').toUpperCase()
+        if (ch) setInitial(ch)
+      } catch { /* ignore */ }
+    })()
+  }, [])
+  return initial
 }
 
-function ConvItem({ c, activeId, onSelect, onDelete, onPin }: {
-  c: Conv; activeId: string | null
-  onSelect: (c: Conv) => void; onDelete: (id: string) => void; onPin: (id: string) => void
-}) {
-  const [menu, setMenu] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (!menu) return
-    const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setMenu(false) }
-    document.addEventListener('mousedown', h)
-    return () => document.removeEventListener('mousedown', h)
-  }, [menu])
-  const isActive = c.id === activeId
-  return (
-    <div ref={ref} style={{ position: 'relative', marginBottom: 1 }}>
-      <button
-        onClick={() => onSelect(c)}
-        className="aiq-conv-btn"
-        style={{
-          width: '100%', padding: '8px 10px', borderRadius: 8,
-          border: 'none', cursor: 'pointer', textAlign: 'left',
-          display: 'flex', flexDirection: 'column', gap: 2,
-          background: isActive ? 'var(--ai-accent-dim)' : 'transparent',
-          transition: 'background 0.1s',
-        }}
-        onMouseEnter={e => { if (!isActive) (e.currentTarget as HTMLButtonElement).style.background = 'var(--ai-bg2)' }}
-        onMouseLeave={e => { if (!isActive) (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
-      >
-        <span style={{
-          fontSize: 13, fontWeight: isActive ? 600 : 400,
-          color: 'var(--ai-text)',
-          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-          maxWidth: 180, fontFamily: 'DM Sans,sans-serif',
-          display: 'block',
-        }}>
-          {c.isPinned && <span style={{ fontSize: 8, marginRight: 4, color: '#2563EB' }}>*</span>}
-          {c.title}
-        </span>
-        <span style={{ fontSize: 11, color: '#8C8C8C', fontFamily: 'DM Sans,sans-serif' }}>
-          {fmt(c.updatedAt)}
-        </span>
-      </button>
-      <button
-        className="aiq-conv-dots"
-        onClick={e => { e.stopPropagation(); setMenu(m => !m) }}
-        style={{
-          position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)',
-          width: 20, height: 20, border: 'none', background: 'none',
-          cursor: 'pointer', color: '#8C8C8C', opacity: 0,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          borderRadius: 4, padding: 0,
-        }}
-      >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-          <circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/>
-        </svg>
-      </button>
-      {menu && (
-        <div style={{
-          position: 'absolute', right: 6, top: 'calc(100% - 4px)', zIndex: 50,
-          background: 'var(--ai-bg)', borderRadius: 8,
-          boxShadow: '0 4px 16px rgba(0,0,0,0.15)', minWidth: 140, overflow: 'hidden',
-        }}>
-          {[
-            { label: c.isPinned ? 'Desepingler' : 'Epingler', action: () => { onPin(c.id); setMenu(false) } },
-            { label: 'Supprimer', action: () => { onDelete(c.id); setMenu(false) }, danger: true },
-          ].map(it => (
-            <button key={it.label} onClick={it.action} style={{
-              display: 'block', width: '100%', padding: '8px 12px',
-              border: 'none', background: 'none', cursor: 'pointer',
-              textAlign: 'left', fontSize: 12, fontFamily: 'DM Sans,sans-serif',
-              color: (it as { danger?: boolean }).danger ? '#EF4444' : 'var(--ai-text)',
-              transition: 'background 0.1s',
-            }}
-              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--ai-bg2)' }}
-              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
-            >
-              {it.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  )
+function filterConvsByView(convs: Conv[], view: SidebarView): Conv[] {
+  if (view === 'projects')  return convs.filter(c => c.isProject)
+  if (view === 'networks')  return convs.filter(c => c.agent === 'networks')
+  // 'training' = par défaut : convs sans agent + agent === 'training', hors projets
+  return convs.filter(c => !c.isProject && (c.agent === undefined || c.agent === 'training'))
 }
 
 export default function AISidebar({
-  convs, activeId, model, onSelect, onDelete, onNew, onPin, onModelChange, onClose, persistent = false,
+  convs, activeId, onSelect, onDelete, onNew, onPin, onClose, persistent = false,
 }: Props) {
-  const [search, setSearch] = useState('')
-  const filtered = search ? convs.filter(c => c.title.toLowerCase().includes(search.toLowerCase())) : convs
-  const pinned = filtered.filter(c => c.isPinned)
-  const recent = filtered.filter(c => !c.isPinned)
+  const [view, setView] = useState<SidebarView>('training')
+  const initial = useUserInitial()
+  const filtered = filterConvsByView(convs, view)
 
   const panel = (
-    <div className="aiq-sidebar" style={{
-      width: persistent ? 220 : 260, height: '100%',
-      background: 'var(--aiq-sidebar-bg)',
-      borderRight: '1px solid rgba(0,0,0,0.06)',
+    <div style={{
+      width: persistent ? 272 : 288, height: '100%',
+      background: SIDEBAR_BG, color: '#FFFFFF',
       display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      fontFamily: 'DM Sans, sans-serif',
     }}>
-      {/* Header */}
-      <div style={{ padding: '16px 12px 8px', flexShrink: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px', marginBottom: 12 }}>
-          <span style={{
-            fontSize: 11, fontWeight: 700, color: '#8C8C8C',
-            letterSpacing: '0.08em', textTransform: 'uppercase',
-            fontFamily: 'DM Sans,sans-serif',
+      {/* ── ZONE HAUTE — App name + Avatar ── */}
+      <div style={{ padding: '20px 20px 16px', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h1 style={{
+            margin: 0,
+            fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em',
+            color: '#FFFFFF', lineHeight: 1,
+            fontFamily: 'Syne, DM Sans, sans-serif',
           }}>
-            Conversations
-          </span>
+            Hybrid
+          </h1>
           <button
-            onClick={onNew}
-            title="Nouvelle discussion"
+            aria-label="Profil"
             style={{
-              width: 28, height: 28, borderRadius: 8, border: 'none',
-              background: 'transparent', cursor: 'pointer', color: '#8C8C8C',
+              width: 36, height: 36, borderRadius: 999, border: 'none',
+              background: '#3A3A3A', color: '#FFFFFF',
+              fontSize: 13, fontWeight: 500,
+              cursor: 'pointer', transition: 'background-color 120ms',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
-              transition: 'background 0.1s',
             }}
-            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(0,0,0,0.08)' }}
-            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#444' }}
+            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = '#3A3A3A' }}
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-              <path d="M7 1v12M1 7h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-            </svg>
+            {initial}
           </button>
         </div>
-        <div style={{ position: 'relative' }}>
-          <svg
-            width="13" height="13" viewBox="0 0 13 13" fill="none"
-            style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}
-          >
-            <circle cx="5.5" cy="5.5" r="4.5" stroke="#8C8C8C" strokeWidth="1.3"/>
-            <path d="M9 9l3 3" stroke="#8C8C8C" strokeWidth="1.3" strokeLinecap="round"/>
-          </svg>
-          <input
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            placeholder="Rechercher..."
-            style={{
-              width: '100%', height: 32, paddingLeft: 30, paddingRight: 10,
-              borderRadius: 8, border: 'none',
-              background: 'var(--ai-bg2)',
-              fontSize: 13, color: 'var(--ai-text)',
-              fontFamily: 'DM Sans,sans-serif', outline: 'none',
-              boxSizing: 'border-box',
-            }}
-          />
-        </div>
       </div>
 
-      {/* Conversation list */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: '4px 8px' }}>
-        {convs.length === 0 && (
-          <p style={{ textAlign: 'center', fontSize: 12, color: '#8C8C8C', marginTop: 24, fontFamily: 'DM Sans,sans-serif' }}>
-            Aucune conversation
-          </p>
-        )}
-        {pinned.length > 0 && (
-          <>
-            <p style={{ fontSize: 10, color: '#8C8C8C', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', margin: '4px 4px 4px' }}>
-              Epingles
-            </p>
-            {pinned.map(c => <ConvItem key={c.id} c={c} activeId={activeId} onSelect={onSelect} onDelete={onDelete} onPin={onPin}/>)}
-          </>
-        )}
-        {recent.map(c => <ConvItem key={c.id} c={c} activeId={activeId} onSelect={onSelect} onDelete={onDelete} onPin={onPin}/>)}
-      </div>
+      {/* ── ZONE NAVIGATION — 3 items ── */}
+      <nav style={{ padding: '0 12px 16px', flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <NavItem
+          icon={<ProjectsIcon size={18} />}
+          label="Projets"
+          active={view === 'projects'}
+          onClick={() => setView('projects')}
+        />
+        <NavItem
+          icon={<LogoOfficial size={18} />}
+          label="Training"
+          active={view === 'training'}
+          onClick={() => setView('training')}
+        />
+        <NavItem
+          icon={<NetworksIcon size={18} />}
+          label="Networks"
+          active={view === 'networks'}
+          onClick={() => setView('networks')}
+        />
+      </nav>
 
-      {/* Agent selector */}
-      <div style={{ padding: '10px 12px 14px', flexShrink: 0 }}>
-        <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#8C8C8C', margin: '0 0 8px 4px', fontFamily: 'DM Sans,sans-serif' }}>
-          Agent
+      {/* ── SÉPARATEUR + LABEL ── */}
+      <div style={{ padding: '8px 20px 4px', flexShrink: 0 }}>
+        <p style={{
+          margin: 0, fontSize: 11, fontWeight: 500,
+          color: 'rgba(255,255,255,0.40)',
+          textTransform: 'uppercase', letterSpacing: '0.08em',
+        }}>
+          {view === 'projects' ? 'Projets' : 'Récents'}
         </p>
-        <div style={{ display: 'flex', gap: 6 }}>
-          {AGENTS.map(a => (
-            <button
-              key={a.id}
-              onClick={() => onModelChange(a.id)}
-              style={{
-                flex: 1, height: 32, borderRadius: 8,
-                border: 'none', cursor: 'pointer',
-                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5,
-                fontSize: 11, fontWeight: 600, fontFamily: 'DM Sans,sans-serif',
-                transition: 'all 0.15s',
-                background: model === a.id ? '#FFFFFF' : 'transparent',
-                color: model === a.id ? '#0A0A0A' : '#8C8C8C',
-                boxShadow: model === a.id ? '0 1px 4px rgba(0,0,0,0.10)' : 'none',
-              }}
-              onMouseEnter={e => { if (model !== a.id) (e.currentTarget as HTMLButtonElement).style.background = 'rgba(0,0,0,0.05)' }}
-              onMouseLeave={e => { if (model !== a.id) (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
-            >
-              <AgentIcon agent={a.id} size={13} />
-              <span>{a.name}</span>
-            </button>
-          ))}
-        </div>
+      </div>
+
+      {/* ── LISTE CONVERSATIONS ── */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '4px 8px' }}>
+        <ConvList
+          convs={filtered}
+          activeId={activeId}
+          onSelect={onSelect}
+          onDelete={onDelete}
+          onPin={onPin}
+          emptyLabel={
+            view === 'projects'
+              ? 'Aucun projet pour le moment'
+              : view === 'networks'
+                ? 'Aucune conversation Networks'
+                : 'Aucune conversation'
+          }
+        />
+      </div>
+
+      {/* ── BOUTON NOUVELLE CONVERSATION ── */}
+      <div style={{ padding: '12px 16px 24px', flexShrink: 0 }}>
+        <button
+          onClick={onNew}
+          style={{
+            width: '100%', height: 48, borderRadius: 999,
+            background: '#FFFFFF', color: '#1A1A1A', border: 'none',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            fontSize: 14, fontWeight: 600, fontFamily: 'DM Sans, sans-serif',
+            cursor: 'pointer', transition: 'background-color 150ms, transform 150ms',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+          }}
+          onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.92)' }}
+          onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = '#FFFFFF' }}
+          onMouseDown={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'scale(0.98)' }}
+          onMouseUp={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1)' }}
+        >
+          <PlusIcon size={16} strokeWidth={2.4} />
+          Nouvelle conversation
+        </button>
       </div>
     </div>
   )
@@ -244,8 +175,24 @@ export default function AISidebar({
   if (persistent) return panel
   return (
     <div style={{ position: 'fixed', inset: 0, zIndex: 80 }}>
-      <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.2)' }} onClick={onClose} />
-      <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0 }}>{panel}</div>
+      <div
+        style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(0,0,0,0.30)', backdropFilter: 'blur(2px)',
+          animation: 'aisb_fade 200ms ease forwards',
+        }}
+        onClick={onClose}
+      />
+      <div style={{
+        position: 'absolute', top: 0, left: 0, bottom: 0,
+        animation: 'aisb_slidein 240ms cubic-bezier(0.16,1,0.3,1) forwards',
+      }}>
+        {panel}
+      </div>
+      <style>{`
+        @keyframes aisb_fade { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes aisb_slidein { from { transform: translateX(-100%) } to { transform: translateX(0) } }
+      `}</style>
     </div>
   )
 }

--- a/src/components/ai/sidebar/ConvList.tsx
+++ b/src/components/ai/sidebar/ConvList.tsx
@@ -1,0 +1,147 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+
+export interface ConvLike {
+  id: string
+  title: string
+  updatedAt: number
+  isPinned?: boolean
+}
+
+interface Props {
+  convs: ConvLike[]
+  activeId: string | null
+  onSelect: (c: ConvLike) => void
+  onDelete: (id: string) => void
+  onPin: (id: string) => void
+  emptyLabel?: string
+}
+
+function fmt(ts: number): string {
+  const d = Date.now() - ts
+  if (d < 60_000)     return 'instant'
+  if (d < 3_600_000)  return `${Math.floor(d / 60_000)} min`
+  if (d < 86_400_000) return `${Math.floor(d / 3_600_000)} h`
+  return new Date(ts).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
+}
+
+function ConvRow({ c, active, onSelect, onDelete, onPin }: {
+  c: ConvLike; active: boolean
+  onSelect: (c: ConvLike) => void
+  onDelete: (id: string) => void
+  onPin: (id: string) => void
+}) {
+  const [menu, setMenu] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!menu) return
+    const h = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setMenu(false) }
+    document.addEventListener('mousedown', h)
+    return () => document.removeEventListener('mousedown', h)
+  }, [menu])
+  return (
+    <div ref={ref} style={{ position: 'relative', marginBottom: 1 }}>
+      <button
+        onClick={() => onSelect(c)}
+        style={{
+          width: '100%', textAlign: 'left',
+          padding: '8px 12px', borderRadius: 12, border: 'none',
+          background: active ? 'rgba(255,255,255,0.10)' : 'transparent',
+          cursor: 'pointer', transition: 'background-color 100ms',
+          fontFamily: 'DM Sans, sans-serif',
+        }}
+        onMouseEnter={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.05)' }}
+        onMouseLeave={e => { if (!active) (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
+      >
+        <p style={{
+          margin: 0, fontSize: 13, fontWeight: 500,
+          color: 'rgba(255,255,255,0.92)', lineHeight: 1.35,
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}>
+          {c.isPinned && <span style={{ marginRight: 4, color: '#9ec5ff' }}>★</span>}
+          {c.title || 'Nouvelle discussion'}
+        </p>
+        <p style={{ margin: '2px 0 0', fontSize: 11, color: 'rgba(255,255,255,0.40)' }}>
+          {fmt(c.updatedAt)}
+        </p>
+      </button>
+      <button
+        onClick={e => { e.stopPropagation(); setMenu(m => !m) }}
+        aria-label="Options"
+        style={{
+          position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)',
+          width: 22, height: 22, border: 'none', background: 'transparent',
+          color: 'rgba(255,255,255,0.5)', cursor: 'pointer', borderRadius: 6,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/>
+        </svg>
+      </button>
+      {menu && (
+        <div style={{
+          position: 'absolute', right: 6, top: 'calc(100% - 2px)', zIndex: 50,
+          background: '#262626', border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 10, minWidth: 150, overflow: 'hidden',
+          boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+        }}>
+          {[
+            { label: c.isPinned ? 'Désépingler' : 'Épingler', action: () => { onPin(c.id); setMenu(false) } },
+            { label: 'Supprimer', action: () => { onDelete(c.id); setMenu(false) }, danger: true },
+          ].map(it => (
+            <button key={it.label} onClick={it.action} style={{
+              display: 'block', width: '100%', padding: '9px 12px',
+              border: 'none', background: 'transparent', cursor: 'pointer',
+              textAlign: 'left', fontSize: 12, fontFamily: 'DM Sans, sans-serif',
+              color: (it as { danger?: boolean }).danger ? '#ff6b6b' : 'rgba(255,255,255,0.9)',
+            }}
+              onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.06)' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent' }}
+            >
+              {it.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ConvList({ convs, activeId, onSelect, onDelete, onPin, emptyLabel }: Props) {
+  if (convs.length === 0) {
+    return (
+      <p style={{
+        textAlign: 'center', fontSize: 12, color: 'rgba(255,255,255,0.35)',
+        margin: '20px 12px', fontFamily: 'DM Sans, sans-serif',
+      }}>
+        {emptyLabel ?? 'Aucune conversation'}
+      </p>
+    )
+  }
+  const pinned = convs.filter(c => c.isPinned)
+  const recent = convs.filter(c => !c.isPinned)
+  return (
+    <>
+      {pinned.length > 0 && (
+        <>
+          <p style={{
+            fontSize: 10, color: 'rgba(255,255,255,0.35)', fontWeight: 600,
+            textTransform: 'uppercase', letterSpacing: '0.08em',
+            margin: '6px 12px 4px', fontFamily: 'DM Sans, sans-serif',
+          }}>Épinglés</p>
+          {pinned.map(c => (
+            <ConvRow key={c.id} c={c} active={c.id === activeId}
+              onSelect={onSelect} onDelete={onDelete} onPin={onPin} />
+          ))}
+        </>
+      )}
+      {recent.map(c => (
+        <ConvRow key={c.id} c={c} active={c.id === activeId}
+          onSelect={onSelect} onDelete={onDelete} onPin={onPin} />
+      ))}
+    </>
+  )
+}
+
+export default ConvList

--- a/src/components/ai/sidebar/LogoOfficial.tsx
+++ b/src/components/ai/sidebar/LogoOfficial.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+/**
+ * Logo officiel THW — utilise /public/logo.png.
+ * Source unique du shuriken THW pour toute l'interface IA.
+ */
+export function LogoOfficial({ size = 18, alt = 'THW' }: { size?: number; alt?: string }) {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src="/logo.png"
+      alt={alt}
+      width={size}
+      height={size}
+      style={{ width: size, height: size, objectFit: 'contain', display: 'block', flexShrink: 0 }}
+    />
+  )
+}
+
+export default LogoOfficial

--- a/src/components/ai/sidebar/NavIcons.tsx
+++ b/src/components/ai/sidebar/NavIcons.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+export function ProjectsIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 7a2 2 0 0 1 2-2h3.6a2 2 0 0 1 1.4.6l1 1H19a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/>
+      <path d="M3 10h18"/>
+    </svg>
+  )
+}
+
+export function NetworksIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" />
+      <path d="M12 3a13 13 0 0 1 0 18" />
+      <path d="M12 3a13 13 0 0 0 0 18" />
+    </svg>
+  )
+}
+
+export function PlusIcon({ size = 16, strokeWidth = 2 }: { size?: number; strokeWidth?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+      <path d="M8 2v12M2 8h12" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function CloseIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none">
+      <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function FolderItemIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 7a2 2 0 0 1 2-2h3.6a2 2 0 0 1 1.4.6l1 1H19a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/>
+    </svg>
+  )
+}

--- a/src/components/ai/sidebar/NavItem.tsx
+++ b/src/components/ai/sidebar/NavItem.tsx
@@ -1,0 +1,56 @@
+'use client'
+import type { ReactNode } from 'react'
+
+interface Props {
+  icon: ReactNode
+  label: string
+  onClick: () => void
+  active?: boolean
+}
+
+export function NavItem({ icon, label, onClick, active = false }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 12px',
+        borderRadius: 12,
+        border: 'none',
+        cursor: 'pointer',
+        fontFamily: 'DM Sans, sans-serif',
+        fontSize: 15,
+        fontWeight: 500,
+        textAlign: 'left',
+        background: active ? 'rgba(255,255,255,0.10)' : 'transparent',
+        color: active ? '#FFFFFF' : 'rgba(255,255,255,0.72)',
+        transition: 'background-color 100ms, color 100ms',
+      }}
+      onMouseEnter={e => {
+        if (!active) {
+          (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.05)'
+          ;(e.currentTarget as HTMLButtonElement).style.color = '#FFFFFF'
+        }
+      }}
+      onMouseLeave={e => {
+        if (!active) {
+          (e.currentTarget as HTMLButtonElement).style.background = 'transparent'
+          ;(e.currentTarget as HTMLButtonElement).style.color = 'rgba(255,255,255,0.72)'
+        }
+      }}
+    >
+      <span style={{
+        width: 20, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        opacity: active ? 1 : 0.75, flexShrink: 0,
+      }}>
+        {icon}
+      </span>
+      {label}
+    </button>
+  )
+}
+
+export default NavItem


### PR DESCRIPTION
- Fond #1A1A1A, titre "Hybrid" 28px + avatar avec initiale Supabase
- 3 NavItems : Projets / Training (logo officiel) / Networks
- Liste conversations filtrée par vue (training / networks / projects)
- Bouton pill blanc "Nouvelle conversation" en bas
- Backdrop + slide-in 240ms sur mobile
- Header IA : logo PNG officiel (/logo.png) au lieu du SVG dessiné, label "Training" au lieu d'Athéna/Zeus/Hermès
- Empty state AIPanel : logo officiel taille 52 au lieu d'AgentIcon
- Helpers extraits (NavItem, NavIcons, ConvList, LogoOfficial) — chaque fichier < 200 lignes
- PROMPT_IA_SIDEBAR_V2.md : spec à la racine