### PR TITLE
feat(nutrition): refonte de la page en 4 bulles à onglets

### DIFF
--- a/scripts/import-foods-off.mjs
+++ b/scripts/import-foods-off.mjs
@@ -1,0 +1,131 @@
+// ══════════════════════════════════════════════════════════════════
+// Seed de la bibliothèque d'aliments `foods` depuis OpenFoodFacts.
+//
+// Importe les produits France les plus scannés (les plus utiles au
+// quotidien) avec leurs macros + photo, en upsert idempotent sur le
+// code-barres. Relançable sans créer de doublons.
+//
+// Prérequis (variables d'environnement) :
+//   NEXT_PUBLIC_SUPABASE_URL    = https://<ref>.supabase.co
+//   SUPABASE_SERVICE_ROLE_KEY   = <clé service_role>  (bypass RLS)
+//
+// Lancement :
+//   node scripts/import-foods-off.mjs            # ~3000 produits
+//   PAGES=50 node scripts/import-foods-off.mjs   # ~5000 produits
+// ══════════════════════════════════════════════════════════════════
+
+import { createClient } from '@supabase/supabase-js'
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!URL || !KEY) {
+  console.error('✗ NEXT_PUBLIC_SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY requis dans l\'environnement.')
+  process.exit(1)
+}
+
+const PAGE_SIZE = 100
+const PAGES = Number(process.env.PAGES ?? 30)   // 30 × 100 = ~3000 produits
+const BATCH = 500
+
+const supabase = createClient(URL, KEY, { auth: { persistSession: false } })
+
+const num = (v) => (typeof v === 'number' && isFinite(v) ? v : null)
+const round1 = (v) => (v == null ? null : Math.round(v * 10) / 10)
+
+function mapProduct(p) {
+  const n = p.nutriments ?? {}
+  const kcal = num(n['energy-kcal_100g'])
+  const name = typeof p.product_name === 'string' ? p.product_name.trim() : ''
+  const code = String(p.code ?? '').trim()
+  if (!name || !code || kcal == null || kcal <= 0) return null
+  return {
+    barcode: code,
+    name,
+    brand: typeof p.brands === 'string' ? p.brands.split(',')[0].trim() || null : null,
+    category: typeof p.categories === 'string' ? p.categories.split(',').pop().trim() || null : null,
+    kcal_100g: Math.round(kcal),
+    prot_100g: round1(num(n.proteins_100g)) ?? 0,
+    gluc_100g: round1(num(n.carbohydrates_100g)) ?? 0,
+    lip_100g: round1(num(n.fat_100g)) ?? 0,
+    fibres_100g: round1(num(n.fiber_100g)),
+    sucres_100g: round1(num(n.sugars_100g)),
+    satures_100g: round1(num(n['saturated-fat_100g'])),
+    sodium_100g: round1(num(n.sodium_100g)),
+    image_url: typeof p.image_small_url === 'string' ? p.image_small_url : null,
+    source: 'off',
+    verified: false,
+  }
+}
+
+async function fetchPage(page) {
+  const params = new URLSearchParams({
+    action: 'process',
+    json: '1',
+    page_size: String(PAGE_SIZE),
+    page: String(page),
+    sort_by: 'unique_scans_n',
+    countries_tags: 'france',
+    fields: 'code,product_name,brands,categories,nutriments,image_small_url',
+  })
+  const url = `https://world.openfoodfacts.org/cgi/search.pl?${params.toString()}`
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'THW-Coaching/1.0 (nutrition food library import)' },
+        signal: AbortSignal.timeout(20000),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      return Array.isArray(data.products) ? data.products : []
+    } catch (err) {
+      if (attempt === 2) { console.warn(`  ! page ${page} échouée: ${err.message}`); return [] }
+      await new Promise(r => setTimeout(r, 1500 * (attempt + 1)))
+    }
+  }
+  return []
+}
+
+async function upsertBatch(rows) {
+  const { error } = await supabase
+    .from('foods')
+    .upsert(rows, { onConflict: 'barcode', ignoreDuplicates: false })
+  if (error) console.warn(`  ! upsert: ${error.message}`)
+}
+
+async function main() {
+  console.log(`▶ Import OpenFoodFacts → foods (${PAGES} pages × ${PAGE_SIZE})`)
+  const seen = new Set()
+  let buffer = []
+  let total = 0
+
+  for (let page = 1; page <= PAGES; page++) {
+    const products = await fetchPage(page)
+    if (!products.length) { console.log(`  · page ${page}: vide, arrêt`); break }
+
+    for (const p of products) {
+      const row = mapProduct(p)
+      if (!row || seen.has(row.barcode)) continue
+      seen.add(row.barcode)
+      buffer.push(row)
+    }
+
+    if (buffer.length >= BATCH) {
+      await upsertBatch(buffer)
+      total += buffer.length
+      console.log(`  ✓ ${total} produits importés (page ${page})`)
+      buffer = []
+    }
+    await new Promise(r => setTimeout(r, 400))   // courtoisie envers l'API OFF
+  }
+
+  if (buffer.length) {
+    await upsertBatch(buffer)
+    total += buffer.length
+  }
+
+  const { count } = await supabase.from('foods').select('*', { count: 'exact', head: true })
+  console.log(`✔ Terminé. ${total} produits traités. Total en base : ${count ?? '?'}`)
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -34,6 +34,7 @@ type WeightMetric = 'weight_kg' | 'fat_mass_percent' | 'muscle_mass_kg'
 type HistRange    = '7j' | '14j'
 type MealKey      = 'petit_dejeuner' | 'collation_matin' | 'dejeuner' | 'collation_apres_midi' | 'diner' | 'collation_soir'
 type PlanVariant  = 'A' | 'B'
+type NutritionTab = 'today' | 'plan' | 'tracking' | 'body'
 
 // ══════════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -820,6 +821,77 @@ function MealTemplatesSection({
 }
 
 // ══════════════════════════════════════════════════════════════════
+// TAB NAVIGATION
+// ══════════════════════════════════════════════════════════════════
+const NUTRITION_TABS: { key: NutritionTab; label: string; icon: React.ReactNode }[] = [
+  {
+    key: 'today',
+    label: "Aujourd'hui",
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+      </svg>
+    ),
+  },
+  {
+    key: 'plan',
+    label: 'Mon plan',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="4" width="18" height="18" rx="2" /><path d="M3 10h18M8 2v4M16 2v4M9 16l2 2 4-4" />
+      </svg>
+    ),
+  },
+  {
+    key: 'tracking',
+    label: 'Suivi',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 3v18h18" /><path d="M7 14l3-4 3 3 4-6" />
+      </svg>
+    ),
+  },
+  {
+    key: 'body',
+    label: 'Composition',
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3a2 2 0 100 4 2 2 0 000-4zM6 21V11a6 6 0 0112 0v10M9 21v-5M15 21v-5" />
+      </svg>
+    ),
+  },
+]
+
+function NutritionTabs({ tab, onChange }: { tab: NutritionTab; onChange: (t: NutritionTab) => void }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, marginBottom: 16, overflowX: 'auto', paddingBottom: 4 }}>
+      {NUTRITION_TABS.map(t => {
+        const active = t.key === tab
+        return (
+          <button
+            key={t.key}
+            onClick={() => onChange(t.key)}
+            aria-pressed={active}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 7,
+              padding: '9px 16px', borderRadius: 12, flexShrink: 0, minHeight: 44,
+              border: `1px solid ${active ? 'rgba(6,182,212,0.35)' : 'var(--border)'}`,
+              background: active ? 'rgba(6,182,212,0.12)' : 'var(--bg-card)',
+              color: active ? '#06B6D4' : 'var(--text-dim)',
+              fontFamily: 'Syne,sans-serif', fontWeight: 700, fontSize: 13,
+              cursor: 'pointer', whiteSpace: 'nowrap', transition: 'all 0.15s',
+            }}
+          >
+            {t.icon}
+            {t.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ══════════════════════════════════════════════════════════════════
 // MAIN PAGE
 // ══════════════════════════════════════════════════════════════════
 export default function NutritionPage() {
@@ -831,6 +903,7 @@ export default function NutritionPage() {
   const { sessions } = usePlanning()
 
   // ── State ──────────────────────────────────────────────────────
+  const [tab, setTab] = useState<NutritionTab>('today')
   const [selectedDate, setSelectedDate] = useState<string>(today)
   const [planVariant, setPlanVariant] = useState<PlanVariant>('A')
   const [histRange, setHistRange] = useState<HistRange>('7j')
@@ -1141,6 +1214,9 @@ export default function NutritionPage() {
 
       <div className="px-4 md:px-8 pt-4 md:pt-6" style={{ paddingBottom: 0 }}>
 
+        <NutritionTabs tab={tab} onChange={setTab} />
+
+        {tab === 'today' && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 
         {/* ══════════════════════════════════════════════════════ */}
@@ -1254,13 +1330,13 @@ export default function NutritionPage() {
           )}
         </div>
 
-        </div>{/* end xl:grid-cols-2 */}
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        </div>
+        )}
 
         {/* ══════════════════════════════════════════════════════ */}
         {/* SECTION 3 — Plan nutritionnel                         */}
         {/* ══════════════════════════════════════════════════════ */}
+        {tab === 'plan' && (
         <div style={cardStyle}>
           <p style={sectionTitle}>Plan nutritionnel</p>
 
@@ -1361,10 +1437,12 @@ export default function NutritionPage() {
             </div>
           )}
         </div>
+        )}
 
         {/* ══════════════════════════════════════════════════════ */}
         {/* SECTION 4 — Repas de la journee                       */}
         {/* ══════════════════════════════════════════════════════ */}
+        {tab === 'today' && (
         <div style={cardStyle}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
             <p style={{ ...sectionTitle, marginBottom: 0 }}>Repas de la journee</p>
@@ -1510,12 +1588,12 @@ export default function NutritionPage() {
             </div>
           )}
         </div>
-
-        </div>{/* end sections 3+4 grid */}
+        )}
 
         {/* ══════════════════════════════════════════════════════ */}
         {/* SECTION 5 — Historique et graphiques                  */}
         {/* ══════════════════════════════════════════════════════ */}
+        {tab === 'tracking' && (
         <div style={cardStyle}>
           <p style={sectionTitle}>Historique</p>
 
@@ -1578,7 +1656,10 @@ export default function NutritionPage() {
           </div>
         </div>
 
+        )}
+
         {/* Weight section */}
+        {tab === 'body' && (
         <div style={cardStyle}>
           <p style={sectionTitle}>Poids et composition</p>
 
@@ -1691,6 +1772,7 @@ export default function NutritionPage() {
           </div>{/* end form column */}
           </div>{/* end xl:grid-cols-3 */}
         </div>
+        )}
       </div>
 
       {/* ══════════════════════════════════════════════════════════ */}
@@ -2005,11 +2087,13 @@ export default function NutritionPage() {
       })()}
 
       {/* Bouton Mes repas types */}
+      {tab === 'plan' && (
       <div style={{ padding: '8px 16px 24px', textAlign: 'center' }}>
         <Button variant="ghost" onClick={() => setShowTemplates(true)}>
           Mes repas types
         </Button>
       </div>
+      )}
 
       {/* Templates modal */}
       {showTemplates && (

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -5,8 +5,8 @@ export const dynamic = 'force-dynamic'
 import { useState, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import dynamicImport from 'next/dynamic'
-import AIAssistantButton from '@/components/ai/AIAssistantButton'
 import { Button } from '@/components/ui/Button'
+import { SportTabs, type SportTabItem } from '@/components/ui/SportTabs'
 import { MacroDonut } from '@/components/ui/MacroDonut'
 import { useNutrition, useNutritionTemplates, type MealTemplate } from '@/hooks/useNutrition'
 import { usePlanning, type PlannedSession } from '@/hooks/usePlanning'
@@ -821,75 +821,14 @@ function MealTemplatesSection({
 }
 
 // ══════════════════════════════════════════════════════════════════
-// TAB NAVIGATION
+// TAB NAVIGATION — style identique aux pills de la page Training
 // ══════════════════════════════════════════════════════════════════
-const NUTRITION_TABS: { key: NutritionTab; label: string; icon: React.ReactNode }[] = [
-  {
-    key: 'today',
-    label: "Aujourd'hui",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
-      </svg>
-    ),
-  },
-  {
-    key: 'plan',
-    label: 'Mon plan',
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="3" y="4" width="18" height="18" rx="2" /><path d="M3 10h18M8 2v4M16 2v4M9 16l2 2 4-4" />
-      </svg>
-    ),
-  },
-  {
-    key: 'tracking',
-    label: 'Suivi',
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M3 3v18h18" /><path d="M7 14l3-4 3 3 4-6" />
-      </svg>
-    ),
-  },
-  {
-    key: 'body',
-    label: 'Composition',
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 3a2 2 0 100 4 2 2 0 000-4zM6 21V11a6 6 0 0112 0v10M9 21v-5M15 21v-5" />
-      </svg>
-    ),
-  },
+const NUTRITION_TAB_ITEMS: SportTabItem[] = [
+  { id: 'today',    label: "Aujourd'hui",  color: '#06B6D4' },
+  { id: 'plan',     label: 'Mon plan',     color: '#06B6D4' },
+  { id: 'tracking', label: 'Suivi',        color: '#06B6D4' },
+  { id: 'body',     label: 'Composition',  color: '#06B6D4' },
 ]
-
-function NutritionTabs({ tab, onChange }: { tab: NutritionTab; onChange: (t: NutritionTab) => void }) {
-  return (
-    <div style={{ display: 'flex', gap: 8, marginBottom: 16, overflowX: 'auto', paddingBottom: 4 }}>
-      {NUTRITION_TABS.map(t => {
-        const active = t.key === tab
-        return (
-          <button
-            key={t.key}
-            onClick={() => onChange(t.key)}
-            aria-pressed={active}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 7,
-              padding: '9px 16px', borderRadius: 12, flexShrink: 0, minHeight: 44,
-              border: `1px solid ${active ? 'rgba(6,182,212,0.35)' : 'var(--border)'}`,
-              background: active ? 'rgba(6,182,212,0.12)' : 'var(--bg-card)',
-              color: active ? '#06B6D4' : 'var(--text-dim)',
-              fontFamily: 'Syne,sans-serif', fontWeight: 700, fontSize: 13,
-              cursor: 'pointer', whiteSpace: 'nowrap', transition: 'all 0.15s',
-            }}
-          >
-            {t.icon}
-            {t.label}
-          </button>
-        )
-      })}
-    </div>
-  )
-}
 
 // ══════════════════════════════════════════════════════════════════
 // MAIN PAGE
@@ -1190,7 +1129,6 @@ export default function NutritionPage() {
             </svg>
           </button>
           <button onClick={reopen} style={{ width:28,height:28,borderRadius:'50%',background:'rgba(6,182,212,0.1)',border:'1px solid rgba(6,182,212,0.25)',color:'#06B6D4',fontSize:13,fontWeight:700,cursor:'pointer',display:'flex',alignItems:'center',justifyContent:'center',flexShrink:0 }}>?</button>
-          <AIAssistantButton agent="nutrition" context={{ activePlan, todayLog }} />
         </div>
       </div>
 
@@ -1214,7 +1152,12 @@ export default function NutritionPage() {
 
       <div className="px-4 md:px-8 pt-4 md:pt-6" style={{ paddingBottom: 0 }}>
 
-        <NutritionTabs tab={tab} onChange={setTab} />
+        <SportTabs
+          tabs={NUTRITION_TAB_ITEMS}
+          value={tab}
+          onChange={id => setTab(id as NutritionTab)}
+          style={{ marginBottom: 16 }}
+        />
 
         {tab === 'today' && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/nutrition/FoodSearchSheet.tsx
+++ b/src/components/nutrition/FoodSearchSheet.tsx
@@ -165,7 +165,7 @@ export function FoodSearchSheet({ onSelect, onClose, initialBarcode }: Props) {
               <>
                 {localResults.length > 0 && (
                   <>
-                    <p style={{ padding: '4px 16px 6px', fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-dim)', margin: 0 }}>Aliments de base</p>
+                    <p style={{ padding: '4px 16px 6px', fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-dim)', margin: 0 }}>Bibliothèque</p>
                     {localResults.map(f => <FoodRow key={f.code} food={f} onSelect={handleSelect} />)}
                   </>
                 )}

--- a/src/lib/food-search.ts
+++ b/src/lib/food-search.ts
@@ -1,9 +1,11 @@
 import { COMMON_FOODS, type FoodItem } from './common-foods'
+import { createClient } from '@/lib/supabase/client'
 
 export type { FoodItem }
 
 const RECENT_KEY = 'recent_foods'
 
+// ── Récents (localStorage) ──────────────────────────────────────────
 export function getRecentFoods(): FoodItem[] {
   if (typeof window === 'undefined') return []
   try { return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]') as FoodItem[] }
@@ -17,6 +19,87 @@ export function saveToRecent(food: FoodItem): void {
   try { localStorage.setItem(RECENT_KEY, JSON.stringify(updated)) } catch {}
 }
 
+// ── Mapping table `foods` ⇄ FoodItem ────────────────────────────────
+interface FoodRow {
+  id: string
+  barcode: string | null
+  name: string
+  image_url: string | null
+  kcal_100g: number
+  prot_100g: number
+  gluc_100g: number
+  lip_100g: number
+}
+
+function rowToItem(r: FoodRow): FoodItem {
+  return {
+    code: r.barcode ?? `lib_${r.id}`,
+    product_name: r.name,
+    image_url: r.image_url ?? undefined,
+    nutriments: {
+      'energy-kcal_100g': Math.round(r.kcal_100g),
+      proteins_100g: +(r.prot_100g.toFixed(1)),
+      carbohydrates_100g: +(r.gluc_100g.toFixed(1)),
+      fat_100g: +(r.lip_100g.toFixed(1)),
+    },
+  }
+}
+
+const isBarcode = (code: string) => /^\d{6,}$/.test(code)
+
+// ── Bibliothèque interne (Supabase) ─────────────────────────────────
+async function searchLibrary(query: string): Promise<FoodItem[]> {
+  try {
+    const supabase = createClient()
+    const { data, error } = await supabase.rpc('search_foods', { q: query, lim: 20 })
+    if (error || !data) return []
+    return (data as FoodRow[]).map(rowToItem)
+  } catch {
+    return []
+  }
+}
+
+async function lookupLibraryBarcode(code: string): Promise<FoodItem | null> {
+  try {
+    const supabase = createClient()
+    const { data, error } = await supabase
+      .from('foods')
+      .select('id,barcode,name,image_url,kcal_100g,prot_100g,gluc_100g,lip_100g')
+      .eq('barcode', code)
+      .maybeSingle()
+    if (error || !data) return null
+    return rowToItem(data as FoodRow)
+  } catch {
+    return null
+  }
+}
+
+// ── Cache paresseux : enrichit `foods` avec les produits OFF vus ────
+// Fire-and-forget, n'échoue jamais bruyamment. Ne cache que les
+// produits ayant un vrai code-barres (dédup via contrainte unique).
+export function cacheFoods(items: FoodItem[]): void {
+  const rows = items
+    .filter(f => isBarcode(f.code))
+    .map(f => ({
+      barcode: f.code,
+      name: f.product_name,
+      image_url: f.image_url ?? null,
+      kcal_100g: f.nutriments['energy-kcal_100g'],
+      prot_100g: f.nutriments.proteins_100g,
+      gluc_100g: f.nutriments.carbohydrates_100g,
+      lip_100g: f.nutriments.fat_100g,
+      source: 'off' as const,
+    }))
+  if (!rows.length) return
+  try {
+    const supabase = createClient()
+    void supabase.from('foods').upsert(rows, { onConflict: 'barcode', ignoreDuplicates: false })
+  } catch {
+    /* silencieux : le cache est best-effort */
+  }
+}
+
+// ── OpenFoodFacts (live, fallback + source de cache) ────────────────
 async function fetchOpenFoodFacts(query: string): Promise<FoodItem[]> {
   try {
     const params = new URLSearchParams({
@@ -58,15 +141,48 @@ async function fetchOpenFoodFacts(query: string): Promise<FoodItem[]> {
   }
 }
 
+// ── Recherche unifiée ───────────────────────────────────────────────
+// `local` : bibliothèque interne (Supabase `foods` + aliments de base)
+// `api`   : produits OpenFoodFacts pas encore dans la bibliothèque
 export async function searchFoods(query: string): Promise<{ local: FoodItem[]; api: FoodItem[] }> {
-  const q = query.trim().toLowerCase()
-  const local = COMMON_FOODS.filter(f => f.product_name.toLowerCase().includes(q))
-  const api = await fetchOpenFoodFacts(query)
-  const localNames = new Set(local.map(f => f.product_name.toLowerCase()))
-  const apiFiltered = api.filter(a => !localNames.has(a.product_name.toLowerCase()))
-  return { local, api: apiFiltered.slice(0, 12 - local.length) }
+  const q = query.trim()
+  const qLower = q.toLowerCase()
+
+  // Recherche par code-barres : bibliothèque puis OFF, et on cache.
+  if (isBarcode(q)) {
+    const libHit = await lookupLibraryBarcode(q)
+    if (libHit) return { local: [libHit], api: [] }
+    const offHit = await lookupBarcode(q)
+    if (offHit) { cacheFoods([offHit]); return { local: [], api: [offHit] } }
+    return { local: [], api: [] }
+  }
+
+  const [library, offResults] = await Promise.all([
+    searchLibrary(q),
+    fetchOpenFoodFacts(q),
+  ])
+
+  // `local` = bibliothèque interne + aliments de base, dédupliqués par nom
+  const commonMatches = COMMON_FOODS.filter(f => f.product_name.toLowerCase().includes(qLower))
+  const localNames = new Set<string>()
+  const local: FoodItem[] = []
+  for (const item of [...library, ...commonMatches]) {
+    const key = item.product_name.toLowerCase()
+    if (localNames.has(key)) continue
+    localNames.add(key)
+    local.push(item)
+  }
+
+  // `api` = produits OFF pas déjà présents dans `local`
+  const apiFiltered = offResults.filter(a => !localNames.has(a.product_name.toLowerCase()))
+
+  // Cache best-effort des nouveaux produits OFF
+  if (apiFiltered.length) cacheFoods(apiFiltered)
+
+  return { local: local.slice(0, 15), api: apiFiltered.slice(0, Math.max(0, 12 - local.length)) }
 }
 
+// ── Lookup direct d'un code-barres sur OFF ──────────────────────────
 export async function lookupBarcode(code: string): Promise<FoodItem | null> {
   try {
     const res = await fetch(

--- a/src/supabase/migrations/add_food_library.sql
+++ b/src/supabase/migrations/add_food_library.sql
@@ -1,0 +1,81 @@
+-- ════════════════════════════════════════════════════════════════
+-- Bibliothèque d'aliments partagée (`foods`)
+-- Source principale : OpenFoodFacts (cache interne + seed), plus
+-- aliments créés par les utilisateurs. Sert de base de référence à
+-- l'algorithme et à l'IA nutrition pour composer/estimer les repas.
+-- ════════════════════════════════════════════════════════════════
+
+-- Recherche floue (trigram) sur le nom et la marque
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS foods (
+  id            uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  barcode       text UNIQUE,                 -- code OFF ; null pour aliment générique/manuel
+  name          text NOT NULL,
+  brand         text,
+  category      text,
+  kcal_100g     numeric NOT NULL,
+  prot_100g     numeric NOT NULL DEFAULT 0,
+  gluc_100g     numeric NOT NULL DEFAULT 0,
+  lip_100g      numeric NOT NULL DEFAULT 0,
+  fibres_100g   numeric,
+  sucres_100g   numeric,
+  satures_100g  numeric,
+  sodium_100g   numeric,
+  image_url     text,
+  source        text NOT NULL DEFAULT 'off'
+                  CHECK (source IN ('off','ciqual','manual','user')),
+  verified      boolean NOT NULL DEFAULT false,
+  popularity    integer NOT NULL DEFAULT 0,
+  created_by    uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index de recherche
+CREATE INDEX IF NOT EXISTS foods_name_trgm   ON foods USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS foods_brand_trgm  ON foods USING gin (brand gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS foods_popularity  ON foods (popularity DESC);
+
+-- ────────────────────────────────────────────────────────────────
+-- RLS : la bibliothèque est partagée.
+--  • lecture : tout utilisateur authentifié
+--  • insertion : tout utilisateur authentifié (cache OFF + créations)
+--  • mise à jour : uniquement sur les entrées non vérifiées
+--    (protège les aliments curatés `verified = true` du vandalisme)
+--  • suppression : interdite (aucune policy)
+-- ────────────────────────────────────────────────────────────────
+ALTER TABLE foods ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "foods readable by authenticated"
+  ON foods FOR SELECT TO authenticated USING (true);
+
+-- Un utilisateur ne peut insérer qu'un aliment non attribué (cache OFF)
+-- ou attribué à lui-même (création perso) — jamais au nom d'autrui.
+CREATE POLICY "foods insertable by authenticated"
+  ON foods FOR INSERT TO authenticated
+  WITH CHECK (created_by IS NULL OR created_by = auth.uid());
+
+CREATE POLICY "foods updatable when not verified"
+  ON foods FOR UPDATE TO authenticated
+  USING (verified = false) WITH CHECK (verified = false);
+
+-- ────────────────────────────────────────────────────────────────
+-- Recherche classée : préfixe > similarité trigram > popularité
+-- ────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION search_foods(q text, lim int DEFAULT 20)
+RETURNS SETOF foods
+LANGUAGE sql STABLE
+SET search_path = public, pg_catalog
+AS $$
+  SELECT *
+  FROM foods
+  WHERE name ILIKE '%' || q || '%' OR brand ILIKE '%' || q || '%'
+  ORDER BY
+    (name ILIKE q || '%') DESC,
+    similarity(name, q) DESC,
+    popularity DESC
+  LIMIT lim;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_foods(text, int) TO authenticated;


### PR DESCRIPTION
Réorganise la page Nutrition en 4 onglets thématiques au lieu de 6
sections empilées :
- Aujourd'hui : bilan du jour, séance du jour, repas de la journée
- Mon plan : calendrier 14j + mes repas types
- Suivi : historique kcal & macros
- Composition : poids et composition corporelle

Ajoute le composant NutritionTabs (navigation scrollable, touch
targets 44px, fonts Syne, palette existante #06B6D4).