### PR TITLE
Planning & Calendar : builder de séance enrichi + refonte Stage

### DIFF
--- a/src/app/ClientShell.tsx
+++ b/src/app/ClientShell.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { SplashScreen } from '@/components/ui/SplashScreen'
+import GlobalSaveToast from '@/components/ui/GlobalSaveToast'
 
 interface ClientShellProps {
   children: React.ReactNode
@@ -31,6 +32,7 @@ export function ClientShell({ children }: ClientShellProps) {
         <SplashScreen onDone={handleSplashDone} />
       )}
       {children}
+      <GlobalSaveToast />
     </>
   )
 }

--- a/src/app/calendar/components/EventModal.tsx
+++ b/src/app/calendar/components/EventModal.tsx
@@ -1,125 +1,145 @@
 'use client'
+// ══════════════════════════════════════════════════════════════════
+// EventModal — éditeur de STAGE (bloc d'entraînement multi-jours).
+// - Sports multi-sélection (sans triathlon, avec muscu)
+// - Durée auto via dates début/fin
+// - Par jour : séances structurées Matin / Après-midi (sport + détail + heure)
+// - Plusieurs parcours libres (GPX) avec carte + profil (ParcoursViewer)
+// - Supprimer + confirmation
+// Données persistées dans le JSONB daily_program (zéro migration) ; parcours
+// dans race_event_files (event_date sentinelle « parcours:… »).
+// ══════════════════════════════════════════════════════════════════
 import { useState, useRef, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
-import { RaceStage } from './types'
+import { RaceStage, StageSport, StageSession } from './types'
+import ParcoursViewer from '@/components/gpx/ParcoursViewer'
 
-interface ExistingFile { file_url: string; file_name: string }
+interface ExistingFile { url: string; name: string; key: string }
 
 interface Props {
   mode?: 'create' | 'edit'
   initialData?: RaceStage
-  initialDate?: string   // jour cliqué → pré-remplit la date de début
+  initialDate?: string
   onClose: () => void
+  onDelete?: () => void
   onSave: (stage: Omit<RaceStage, 'id'>, dayFiles: { date: string; file: File }[]) => Promise<void>
 }
 
+const STAGE_SPORTS: { id: StageSport; label: string; color: string }[] = [
+  { id:'run',   label:'Course à pied', color:'#f97316' },
+  { id:'trail', label:'Trail',         color:'#84cc16' },
+  { id:'bike',  label:'Cyclisme',      color:'#3b82f6' },
+  { id:'swim',  label:'Natation',      color:'#06b6d4' },
+  { id:'hyrox', label:'Hyrox',         color:'#ec4899' },
+  { id:'rowing',label:'Aviron',        color:'#14b8a6' },
+  { id:'muscu', label:'Muscu',         color:'#8b5cf6' },
+]
+const sportLabel = (s: StageSport) => STAGE_SPORTS.find(x => x.id === s)?.label ?? s
+
 const INP = { width:'100%',padding:'7px 10px',borderRadius:8,border:'1px solid var(--border)',background:'var(--input-bg)',color:'var(--text)',fontSize:12,outline:'none' }
 const LBL = { fontSize:10,fontWeight:600 as const,textTransform:'uppercase' as const,letterSpacing:'0.06em',color:'var(--text-dim)',marginBottom:4,display:'block' as const }
+const isGpx = (n: string) => /\.(gpx|tcx|kml)$/i.test(n)
 
 function getDaysBetween(start: string, end: string): string[] {
   if (!start || !end || start > end) return []
   const days: string[] = []
-  const cur = new Date(start)
-  const fin = new Date(end)
-  while (cur <= fin) {
-    days.push(cur.toISOString().split('T')[0])
-    cur.setDate(cur.getDate() + 1)
-  }
+  const cur = new Date(start), fin = new Date(end)
+  while (cur <= fin) { days.push(cur.toISOString().split('T')[0]); cur.setDate(cur.getDate() + 1) }
   return days
 }
+const labelDay = (d: string) => new Date(d + 'T12:00:00').toLocaleDateString('fr-FR', { weekday:'long', day:'numeric', month:'long' })
 
-function labelDay(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('fr-FR', { weekday:'long', day:'numeric', month:'long' })
-}
+type DayProg = Record<string, { matin: StageSession[]; aprem: StageSession[] }>
 
-export default function EventModal({ mode = 'create', initialData, initialDate, onClose, onSave }: Props) {
+export default function EventModal({ mode = 'create', initialData, initialDate, onClose, onDelete, onSave }: Props) {
   const supabase = createClient()
   const isEdit = mode === 'edit'
   const [name,      setName]      = useState(initialData?.name ?? '')
   const [startDate, setStartDate] = useState(initialData?.startDate ?? initialDate ?? '')
-  const [endDate,   setEndDate]   = useState(initialData?.endDate ?? '')
+  const [endDate,   setEndDate]   = useState(initialData?.endDate ?? initialData?.startDate ?? initialDate ?? '')
   const [desc,      setDesc]      = useState(initialData?.description ?? '')
+  const [sports,    setSports]    = useState<StageSport[]>(initialData?.sports ?? [])
   const [saving,    setSaving]    = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
 
-  const [program, setProgram] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {}
-    if (initialData?.dailyProgram) {
-      for (const { date, content } of initialData.dailyProgram) init[date] = content
-    }
+  const [program, setProgram] = useState<DayProg>(() => {
+    const init: DayProg = {}
+    for (const d of initialData?.dailyProgram ?? []) init[d.date] = { matin: d.matin ?? [], aprem: d.aprem ?? [] }
     return init
   })
 
-  const [dayFiles,    setDayFiles]    = useState<Record<string, File | null>>({})
-  const [existingFiles, setExistingFiles] = useState<Record<string, ExistingFile | null>>({})
-  const [excludedDays,  setExcludedDays]  = useState<Set<string>>(new Set())
-  const dayFileRefs = useRef<Record<string, HTMLInputElement | null>>({})
+  const [parcoursNew, setParcoursNew] = useState<File[]>([])
+  const [parcoursExisting, setParcoursExisting] = useState<ExistingFile[]>([])
+  const parcoursRef = useRef<HTMLInputElement>(null)
 
-  const days        = getDaysBetween(startDate, endDate)
-  const visibleDays = days.filter(d => !excludedDays.has(d))
+  const days = getDaysBetween(startDate, endDate)
 
-  // Pre-load existing files in edit mode
+  // Charge les parcours existants (event_date sentinelle « parcours… »)
   useEffect(() => {
     if (!isEdit || !initialData?.id) return
-    supabase
-      .from('race_event_files')
-      .select('event_date, file_url, file_name')
-      .eq('event_id', initialData.id)
+    supabase.from('race_event_files').select('event_date, file_url, file_name').eq('event_id', initialData.id)
       .then(({ data }) => {
         if (!data) return
-        const map: Record<string, ExistingFile> = {}
-        for (const row of data as { event_date: string; file_url: string; file_name: string }[]) {
-          map[row.event_date] = { file_url: row.file_url, file_name: row.file_name }
-        }
-        setExistingFiles(map)
+        const list = (data as { event_date: string; file_url: string; file_name: string }[])
+          .filter(r => (r.event_date ?? '').startsWith('parcours') && isGpx(r.file_name))
+          .map(r => ({ url: r.file_url, name: r.file_name, key: r.event_date }))
+        setParcoursExisting(list)
       })
   }, [isEdit, initialData?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Sync program keys when date range changes
+  // Synchronise les clés de programme avec la plage de dates
   useEffect(() => {
     setProgram(prev => {
-      const next: Record<string, string> = {}
-      days.forEach(d => { next[d] = prev[d] ?? '' })
-      return next
-    })
-    setDayFiles(prev => {
-      const next: Record<string, File | null> = {}
-      days.forEach(d => { next[d] = prev[d] ?? null })
-      return next
-    })
-    // When date range changes, clear excluded days that are no longer in range
-    setExcludedDays(prev => {
-      const next = new Set<string>()
-      prev.forEach(d => { if (days.includes(d)) next.add(d) })
+      const next: DayProg = {}
+      days.forEach(d => { next[d] = prev[d] ?? { matin: [], aprem: [] } })
       return next
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startDate, endDate])
 
-  async function deleteDay(d: string) {
-    // In edit mode: delete file record from DB immediately
-    if (isEdit && initialData?.id) {
-      await supabase
-        .from('race_event_files')
-        .delete()
-        .eq('event_id', initialData.id)
-        .eq('event_date', d)
-    }
-    setExcludedDays(prev => new Set([...prev, d]))
-    setExistingFiles(prev => { const n = { ...prev }; delete n[d]; return n })
-    setDayFiles(prev => { const n = { ...prev }; delete n[d]; return n })
+  function toggleSport(s: StageSport) {
+    setSports(prev => prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s])
+  }
+  const sportOptions = sports.length ? sports : STAGE_SPORTS.map(s => s.id)
+
+  function addSession(date: string, slot: 'matin' | 'aprem') {
+    setProgram(prev => {
+      const day = prev[date] ?? { matin: [], aprem: [] }
+      const ses: StageSession = { sport: sportOptions[0], detail: '', time: slot === 'matin' ? '09:00' : '15:00' }
+      return { ...prev, [date]: { ...day, [slot]: [...day[slot], ses] } }
+    })
+  }
+  function updSession(date: string, slot: 'matin' | 'aprem', i: number, patch: Partial<StageSession>) {
+    setProgram(prev => {
+      const day = prev[date]; if (!day) return prev
+      const arr = day[slot].map((s, idx) => idx === i ? { ...s, ...patch } : s)
+      return { ...prev, [date]: { ...day, [slot]: arr } }
+    })
+  }
+  function rmSession(date: string, slot: 'matin' | 'aprem', i: number) {
+    setProgram(prev => {
+      const day = prev[date]; if (!day) return prev
+      return { ...prev, [date]: { ...day, [slot]: day[slot].filter((_, idx) => idx !== i) } }
+    })
   }
 
   async function handleSave() {
     if (!name.trim() || !startDate || !endDate) return
     setSaving(true)
     try {
-      const dailyProgram = visibleDays.map(d => ({ date: d, content: program[d] ?? '' }))
-      const allDayFiles = Object.entries(dayFiles)
-        .filter((entry): entry is [string, File] => entry[1] !== null && visibleDays.includes(entry[0]))
-        .map(([date, file]) => ({ date, file }))
+      const dailyProgram = days.map(d => {
+        const dp = program[d] ?? { matin: [], aprem: [] }
+        const summary = [...dp.matin, ...dp.aprem]
+          .filter(s => s.detail?.trim() || s.sport)
+          .map(s => `${sportLabel(s.sport)} : ${s.detail || ''}`.trim())
+          .join(' · ')
+        return { date: d, content: summary, matin: dp.matin, aprem: dp.aprem }
+      })
+      const stamp = Date.now()
+      const dayFiles = parcoursNew.map((file, i) => ({ date: `parcours:${stamp}:${i}`, file }))
       await onSave(
-        { name: name.trim(), startDate, endDate, description: desc || undefined, dailyProgram },
-        allDayFiles,
+        { name: name.trim(), startDate, endDate, description: desc || undefined, sports, dailyProgram },
+        dayFiles,
       )
       onClose()
     } catch (e) { console.error('[EventModal save]', e) }
@@ -128,113 +148,84 @@ export default function EventModal({ mode = 'create', initialData, initialDate, 
 
   return (
     <div onClick={onClose} style={{ position:'fixed',inset:0,zIndex:400,background:'rgba(0,0,0,0.55)',backdropFilter:'blur(4px)',display:'flex',alignItems:'center',justifyContent:'center',padding:16,overflowY:'auto' }}>
-      <div onClick={e => e.stopPropagation()} style={{ background:'var(--bg-card)',borderRadius:18,border:'1px solid var(--border-mid)',padding:24,maxWidth:560,width:'100%',maxHeight:'90vh',overflowY:'auto',display:'flex',flexDirection:'column',gap:16 }}>
+      <div onClick={e => e.stopPropagation()} style={{ background:'var(--bg-card)',borderRadius:18,border:'1px solid var(--border-mid)',padding:24,maxWidth:620,width:'100%',maxHeight:'92vh',overflowY:'auto',display:'flex',flexDirection:'column',gap:16 }}>
 
         {/* Header */}
         <div style={{ display:'flex',alignItems:'center',justifyContent:'space-between' }}>
-          <h3 style={{ fontFamily:'Syne,sans-serif',fontSize:16,fontWeight:700,margin:0 }}>
-            {isEdit ? 'Modifier l\'événement' : 'Ajouter un événement'}
-          </h3>
+          <h3 style={{ fontFamily:'Syne,sans-serif',fontSize:16,fontWeight:700,margin:0 }}>{isEdit ? 'Modifier le stage' : 'Ajouter un stage'}</h3>
           <button onClick={onClose} style={{ background:'var(--bg-card2)',border:'1px solid var(--border)',borderRadius:8,padding:'4px 10px',cursor:'pointer',color:'var(--text-dim)',fontSize:14 }}>✕</button>
         </div>
 
         {/* Nom */}
         <div>
-          <label style={LBL}>Nom</label>
+          <label style={LBL}>Nom du stage</label>
           <input style={INP} value={name} onChange={e => setName(e.target.value)} placeholder="Ex: Stage Haute Montagne" />
         </div>
 
-        {/* Dates */}
-        <div style={{ display:'grid',gridTemplateColumns:'1fr 1fr',gap:10 }}>
-          <div>
-            <label style={LBL}>Date de début</label>
-            <input type="date" style={INP} value={startDate} onChange={e => setStartDate(e.target.value)} />
-          </div>
-          <div>
-            <label style={LBL}>Date de fin</label>
-            <input type="date" style={INP} value={endDate} onChange={e => setEndDate(e.target.value)} />
+        {/* Sports multi */}
+        <div>
+          <label style={LBL}>Sports</label>
+          <div style={{ display:'flex',gap:6,flexWrap:'wrap' }}>
+            {STAGE_SPORTS.map(s => {
+              const on = sports.includes(s.id)
+              return (
+                <button key={s.id} onClick={() => toggleSport(s.id)}
+                  style={{ padding:'6px 12px',borderRadius:99,fontSize:11,fontWeight:600,cursor:'pointer',
+                    border:`1px solid ${on ? s.color : 'var(--border)'}`,
+                    background: on ? `${s.color}1f` : 'transparent', color: on ? s.color : 'var(--text-dim)' }}>
+                  {s.label}
+                </button>
+              )
+            })}
           </div>
         </div>
+
+        {/* Dates → durée auto */}
+        <div style={{ display:'grid',gridTemplateColumns:'1fr 1fr',gap:10 }}>
+          <div><label style={LBL}>Date de début</label><input type="date" style={INP} value={startDate} onChange={e => setStartDate(e.target.value)} /></div>
+          <div><label style={LBL}>Date de fin</label><input type="date" style={INP} value={endDate} onChange={e => setEndDate(e.target.value)} /></div>
+        </div>
+        {days.length > 0 && <p style={{ fontSize:11,color:'var(--text-dim)',margin:'-6px 0 0' }}>Durée : <strong style={{ color:'var(--text)' }}>{days.length} jour{days.length > 1 ? 's' : ''}</strong></p>}
 
         {/* Description */}
         <div>
           <label style={LBL}>Description</label>
-          <textarea rows={2} style={{ ...INP, resize:'vertical' as const }} value={desc}
-            onChange={e => setDesc(e.target.value)} placeholder="Objectifs, contexte…" />
+          <textarea rows={2} style={{ ...INP, resize:'vertical' as const }} value={desc} onChange={e => setDesc(e.target.value)} placeholder="Objectifs, contexte…" />
         </div>
 
-        {/* Programme par jour */}
-        {visibleDays.length > 0 && (
+        {/* Programme par jour : Matin / Après-midi */}
+        {days.length > 0 && (
           <div>
-            <label style={LBL}>Programme par jour</label>
-            <div style={{ display:'flex',flexDirection:'column',gap:12 }}>
-              {visibleDays.map(d => {
-                const existing = existingFiles[d]
-                const newF     = dayFiles[d]
+            <label style={LBL}>Programme — Matin / Après-midi</label>
+            <div style={{ display:'flex',flexDirection:'column',gap:14 }}>
+              {days.map(d => {
+                const dp = program[d] ?? { matin: [], aprem: [] }
                 return (
-                  <div key={d} style={{ position:'relative',borderLeft:'2px solid var(--border)',paddingLeft:12 }}>
-                    {/* Day header with delete button */}
-                    <div style={{ display:'flex',alignItems:'center',justifyContent:'space-between',marginBottom:5 }}>
-                      <p style={{ fontSize:11,fontWeight:600,color:'var(--text-mid)',margin:0,textTransform:'capitalize' }}>
-                        {labelDay(d)}
-                      </p>
-                      <button
-                        onClick={() => deleteDay(d)}
-                        disabled={visibleDays.length <= 1}
-                        title="Supprimer ce jour"
-                        style={{
-                          background:'none',border:'none',cursor:visibleDays.length<=1?'not-allowed':'pointer',
-                          color:visibleDays.length<=1?'var(--text-dim)':'#ef4444',
-                          fontSize:13,lineHeight:1,padding:'2px 4px',flexShrink:0,
-                          opacity:visibleDays.length<=1?0.3:1,
-                        }}
-                      >×</button>
-                    </div>
-
-                    <textarea rows={2} style={{ ...INP, resize:'vertical' as const }}
-                      value={program[d] ?? ''} placeholder="Programme de la journée…"
-                      onChange={e => setProgram(prev => ({ ...prev, [d]: e.target.value }))} />
-
-                    {/* Per-day file */}
-                    <div style={{ marginTop:6 }}>
-                      {newF ? (
-                        <div style={{ display:'flex',alignItems:'center',gap:6,padding:'4px 8px',borderRadius:6,background:'var(--bg-card2)',border:'1px solid var(--border)' }}>
-                          <span style={{ flex:1,fontSize:11,color:'var(--text-mid)',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap' }}>
-                            {newF.name}
-                          </span>
-                          <button onClick={() => setDayFiles(prev => ({ ...prev, [d]: null }))}
-                            style={{ background:'none',border:'none',color:'#ef4444',cursor:'pointer',fontSize:12,flexShrink:0 }}>✕</button>
-                        </div>
-                      ) : existing ? (
-                        <div style={{ display:'flex',alignItems:'center',gap:6,padding:'4px 8px',borderRadius:6,background:'var(--bg-card2)',border:'1px solid var(--border)' }}>
-                          <span style={{ fontSize:11 }}>📎</span>
-                          <span style={{ flex:1,fontSize:11,color:'var(--text-mid)',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap' }}>
-                            {existing.file_name}
-                          </span>
-                          <button
-                            onClick={() => dayFileRefs.current[d]?.click()}
-                            style={{ background:'none',border:'none',color:'#3b82f6',cursor:'pointer',fontSize:10,flexShrink:0,whiteSpace:'nowrap' }}>
-                            ↺ Remplacer
+                  <div key={d} style={{ borderLeft:'2px solid var(--border)',paddingLeft:12 }}>
+                    <p style={{ fontSize:11,fontWeight:700,color:'var(--text-mid)',margin:'0 0 8px',textTransform:'capitalize' }}>{labelDay(d)}</p>
+                    {(['matin','aprem'] as const).map(slot => (
+                      <div key={slot} style={{ marginBottom:10 }}>
+                        <p style={{ fontSize:10,fontWeight:600,color:'var(--text-dim)',margin:'0 0 5px' }}>{slot === 'matin' ? 'Matin' : 'Après-midi'}</p>
+                        <div style={{ display:'flex',flexDirection:'column',gap:6 }}>
+                          {dp[slot].map((ses, i) => (
+                            <div key={i} style={{ display:'flex',gap:6,alignItems:'center',flexWrap:'wrap' }}>
+                              <select value={ses.sport} onChange={e => updSession(d, slot, i, { sport: e.target.value as StageSport })}
+                                style={{ ...INP, width:'auto',flex:'none',minWidth:120 }}>
+                                {sportOptions.map(sp => <option key={sp} value={sp}>{sportLabel(sp)}</option>)}
+                              </select>
+                              <input type="time" value={ses.time ?? ''} onChange={e => updSession(d, slot, i, { time: e.target.value })}
+                                style={{ ...INP, width:'auto',flex:'none' }} />
+                              <input value={ses.detail} onChange={e => updSession(d, slot, i, { detail: e.target.value })}
+                                placeholder="Détail de la séance…" style={{ ...INP, flex:1,minWidth:120 }} />
+                              <button onClick={() => rmSession(d, slot, i)} style={{ background:'none',border:'none',color:'#ef4444',cursor:'pointer',fontSize:15,lineHeight:1,padding:'2px 4px',flexShrink:0 }}>×</button>
+                            </div>
+                          ))}
+                          <button onClick={() => addSession(d, slot)} style={{ alignSelf:'flex-start',fontSize:10,color:'var(--text-dim)',background:'var(--bg-card2)',border:'1px dashed var(--border)',borderRadius:7,padding:'5px 10px',cursor:'pointer' }}>
+                            + Séance {slot === 'matin' ? 'du matin' : "de l'après-midi"}
                           </button>
                         </div>
-                      ) : (
-                        <button
-                          onClick={() => dayFileRefs.current[d]?.click()}
-                          style={{ fontSize:10,color:'var(--text-dim)',background:'var(--bg-card2)',border:'1px dashed var(--border)',borderRadius:7,padding:'5px 10px',cursor:'pointer',width:'100%' }}>
-                          + Fichier du jour (GPX, PDF, image…)
-                        </button>
-                      )}
-                      <input
-                        ref={el => { dayFileRefs.current[d] = el }}
-                        type="file"
-                        style={{ display:'none' }}
-                        onChange={e => {
-                          const file = e.target.files?.[0]
-                          if (file) setDayFiles(prev => ({ ...prev, [d]: file }))
-                          e.target.value = ''
-                        }}
-                      />
-                    </div>
+                      </div>
+                    ))}
                   </div>
                 )
               })}
@@ -242,16 +233,53 @@ export default function EventModal({ mode = 'create', initialData, initialDate, 
           </div>
         )}
 
+        {/* Parcours (multiples) */}
+        <div>
+          <label style={LBL}>Parcours</label>
+          <button onClick={() => parcoursRef.current?.click()} style={{ fontSize:11,color:'var(--text-mid)',background:'var(--bg-card2)',border:'1px dashed var(--border)',borderRadius:8,padding:'7px 12px',cursor:'pointer' }}>
+            + Importer un parcours (GPX)
+          </button>
+          <input ref={parcoursRef} type="file" accept=".gpx,.tcx,.kml" style={{ display:'none' }}
+            onChange={e => { const f = e.target.files?.[0]; if (f && isGpx(f.name)) setParcoursNew(prev => [...prev, f]); if (e.target) e.target.value = '' }} />
+          <div style={{ display:'flex',flexDirection:'column',gap:10,marginTop:10 }}>
+            {parcoursExisting.map(p => (
+              <div key={p.key}>
+                <div style={{ display:'flex',alignItems:'center',gap:6,marginBottom:4 }}>
+                  <span style={{ fontSize:11,color:'var(--text-mid)',flex:1,overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap' }}>📍 {p.name}</span>
+                </div>
+                <ParcoursViewer fileUrl={p.url} />
+              </div>
+            ))}
+            {parcoursNew.map((f, i) => (
+              <div key={i}>
+                <div style={{ display:'flex',alignItems:'center',gap:6,marginBottom:4 }}>
+                  <span style={{ fontSize:11,color:'var(--text-mid)',flex:1,overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap' }}>📍 {f.name}</span>
+                  <button onClick={() => setParcoursNew(prev => prev.filter((_, idx) => idx !== i))} style={{ background:'none',border:'none',color:'#ef4444',cursor:'pointer',fontSize:13 }}>✕</button>
+                </div>
+                <ParcoursViewer file={f} />
+              </div>
+            ))}
+          </div>
+        </div>
+
         {/* Boutons */}
-        <div style={{ display:'flex',gap:8 }}>
-          <button onClick={onClose}
-            style={{ flex:1,padding:10,borderRadius:10,background:'var(--bg-card2)',border:'1px solid var(--border)',color:'var(--text-mid)',fontSize:12,cursor:'pointer' }}>
-            Annuler
-          </button>
-          <button onClick={handleSave} disabled={saving || !name.trim() || !startDate || !endDate}
-            style={{ flex:2,padding:10,borderRadius:10,background:'linear-gradient(135deg,#06B6D4,#5b6fff)',border:'none',color:'#fff',fontFamily:'Syne,sans-serif',fontWeight:700,fontSize:12,cursor:saving?'wait':'pointer',opacity:(!name.trim()||!startDate||!endDate)?0.5:1 }}>
-            {saving ? '…' : isEdit ? 'Enregistrer' : '+ Ajouter'}
-          </button>
+        <div style={{ display:'flex',gap:8,alignItems:'center' }}>
+          {isEdit && onDelete && (confirmDelete ? (
+            <div style={{ display:'flex',gap:6,alignItems:'center',flex:1,flexWrap:'wrap' }}>
+              <span style={{ fontSize:12,fontWeight:600,color:'#ef4444' }}>Supprimer ce stage ?</span>
+              <button onClick={onDelete} style={{ padding:'9px 14px',borderRadius:10,background:'#ef4444',border:'none',color:'#fff',fontWeight:700,fontSize:12,cursor:'pointer' }}>Confirmer</button>
+              <button onClick={() => setConfirmDelete(false)} style={{ padding:'9px 12px',borderRadius:10,background:'var(--bg-card2)',border:'1px solid var(--border)',color:'var(--text-mid)',fontSize:12,cursor:'pointer' }}>Annuler</button>
+            </div>
+          ) : (
+            <button onClick={() => setConfirmDelete(true)} style={{ padding:'10px 14px',borderRadius:10,background:'transparent',border:'1px solid #ef4444',color:'#ef4444',fontSize:12,fontWeight:600,cursor:'pointer',flexShrink:0 }}>Supprimer</button>
+          ))}
+          {!confirmDelete && (<>
+            <button onClick={onClose} style={{ flex:1,padding:10,borderRadius:10,background:'var(--bg-card2)',border:'1px solid var(--border)',color:'var(--text-mid)',fontSize:12,cursor:'pointer' }}>Fermer</button>
+            <button onClick={handleSave} disabled={saving || !name.trim() || !startDate || !endDate}
+              style={{ flex:2,padding:10,borderRadius:10,background:'linear-gradient(135deg,#06B6D4,#5b6fff)',border:'none',color:'#fff',fontFamily:'Syne,sans-serif',fontWeight:700,fontSize:12,cursor:saving?'wait':'pointer',opacity:(!name.trim()||!startDate||!endDate)?0.5:1 }}>
+              {saving ? '…' : isEdit ? 'Enregistrer' : 'Ajouter'}
+            </button>
+          </>)}
         </div>
       </div>
     </div>

--- a/src/app/calendar/components/EventModal.tsx
+++ b/src/app/calendar/components/EventModal.tsx
@@ -8,6 +8,7 @@ interface ExistingFile { file_url: string; file_name: string }
 interface Props {
   mode?: 'create' | 'edit'
   initialData?: RaceStage
+  initialDate?: string   // jour cliqué → pré-remplit la date de début
   onClose: () => void
   onSave: (stage: Omit<RaceStage, 'id'>, dayFiles: { date: string; file: File }[]) => Promise<void>
 }
@@ -31,11 +32,11 @@ function labelDay(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('fr-FR', { weekday:'long', day:'numeric', month:'long' })
 }
 
-export default function EventModal({ mode = 'create', initialData, onClose, onSave }: Props) {
+export default function EventModal({ mode = 'create', initialData, initialDate, onClose, onSave }: Props) {
   const supabase = createClient()
   const isEdit = mode === 'edit'
   const [name,      setName]      = useState(initialData?.name ?? '')
-  const [startDate, setStartDate] = useState(initialData?.startDate ?? '')
+  const [startDate, setStartDate] = useState(initialData?.startDate ?? initialDate ?? '')
   const [endDate,   setEndDate]   = useState(initialData?.endDate ?? '')
   const [desc,      setDesc]      = useState(initialData?.description ?? '')
   const [saving,    setSaving]    = useState(false)

--- a/src/app/calendar/components/RaceEditorSheet.tsx
+++ b/src/app/calendar/components/RaceEditorSheet.tsx
@@ -11,19 +11,22 @@ import { Race, RaceLevel, RaceSport, RACE_CFG, SPORT_LABEL, SPORT_COLOR, SPORT_B
 import SportFields from './SportFields'
 import TriSegments from './TriSegments'
 import RaceDropZone from './RaceDropZone'
+import ParcoursViewer from '@/components/gpx/ParcoursViewer'
 import { SegmentCard } from './RaceSegmentCard'
 import { RACE_EDITOR_CSS } from './raceTheme'
 
 interface Props {
   race?: Race; initialDate?: string; onClose: () => void
   onSave: (r: Omit<Race, 'id'>, files: File[], filesBike?: File[], filesRun?: File[]) => Promise<void>
+  onDelete?: () => void
 }
 const SPORTS: RaceSport[] = ['run', 'trail', 'bike', 'swim', 'hyrox', 'triathlon', 'rowing']
 const LEVELS: RaceLevel[] = ['main', 'important', 'secondary', 'gty']  // GTY = donnée existante, conservée
 const LBL: React.CSSProperties = { fontSize: 9.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-dim)', margin: '0 0 6px' }
 const INP: React.CSSProperties = { width: '100%', boxSizing: 'border-box', padding: '9px 11px', borderRadius: 9, border: '1px solid var(--border)', background: 'var(--input-bg)', color: 'var(--text)', fontSize: 13.5, outline: 'none' }
+const findGpx = (list: File[]) => list.find(f => /\.(gpx|tcx|kml)$/i.test(f.name))
 
-export default function RaceEditorSheet({ race, initialDate, onClose, onSave }: Props) {
+export default function RaceEditorSheet({ race, initialDate, onClose, onSave, onDelete }: Props) {
   const isEdit = !!race
   const [sport, setSport] = useState<RaceSport>(race?.sport ?? 'run')
   const [level, setLevel] = useState<RaceLevel>(race?.level ?? 'important')
@@ -32,6 +35,7 @@ export default function RaceEditorSheet({ race, initialDate, onClose, onSave }: 
   const [notes, setNotes] = useState(race?.notes ?? '')
   const [pd, setPd] = useState<Record<string, unknown>>(race?.performanceData ?? {})
   const [saving, setSaving] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
   const [files, setFiles] = useState<File[]>([])
   const [filesBike, setFilesBike] = useState<File[]>([])
   const [filesRun, setFilesRun] = useState<File[]>([])
@@ -105,10 +109,21 @@ export default function RaceEditorSheet({ race, initialDate, onClose, onSave }: 
               <p style={LBL}>Parcours</p>
               {sport === 'triathlon' ? (
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-                  <RaceDropZone label="Parcours vélo" list={filesBike} setter={setFilesBike} />
-                  <RaceDropZone label="Parcours course" list={filesRun} setter={setFilesRun} />
+                  <div>
+                    <RaceDropZone label="Parcours vélo" list={filesBike} setter={setFilesBike} />
+                    {findGpx(filesBike) && <div style={{ marginTop: 10 }}><ParcoursViewer file={findGpx(filesBike)} /></div>}
+                  </div>
+                  <div>
+                    <RaceDropZone label="Parcours course" list={filesRun} setter={setFilesRun} />
+                    {findGpx(filesRun) && <div style={{ marginTop: 10 }}><ParcoursViewer file={findGpx(filesRun)} /></div>}
+                  </div>
                 </div>
-              ) : <RaceDropZone list={files} setter={setFiles} />}
+              ) : (
+                <>
+                  <RaceDropZone list={files} setter={setFiles} />
+                  {findGpx(files) && <div style={{ marginTop: 10 }}><ParcoursViewer file={findGpx(files)} /></div>}
+                </>
+              )}
             </div>
             {/* Notes */}
             <div><p style={LBL}>Notes</p>
@@ -118,9 +133,20 @@ export default function RaceEditorSheet({ race, initialDate, onClose, onSave }: 
 
         {/* Footer sticky */}
         <div style={{ flexShrink: 0, display: 'flex', justifyContent: 'center', gap: 10, padding: '12px 24px', paddingBottom: 'calc(12px + env(safe-area-inset-bottom))', borderTop: '1px solid var(--border)', background: 'var(--bg-card2)' }}>
-          <div style={{ display: 'flex', gap: 10, width: '100%', maxWidth: 900 }}>
-            <button onClick={onClose} style={{ flex: 1, padding: 12, borderRadius: 999, background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-mid)', fontSize: 13.5, fontWeight: 600, cursor: 'pointer' }}>Annuler</button>
-            <button onClick={handleSave} disabled={saving || !name.trim()} style={{ flex: 2, padding: 12, borderRadius: 999, background: SPORT_COLOR[sport], border: 'none', color: '#fff', fontWeight: 700, fontSize: 13.5, cursor: saving ? 'wait' : 'pointer', opacity: !name.trim() ? 0.5 : 1 }}>{saving ? '…' : isEdit ? 'Enregistrer' : 'Ajouter'}</button>
+          <div style={{ display: 'flex', gap: 10, width: '100%', maxWidth: 900, alignItems: 'center' }}>
+            {isEdit && onDelete && (confirmDelete ? (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flex: 1, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 12.5, fontWeight: 600, color: '#ef4444' }}>Supprimer cette course ?</span>
+                <button onClick={onDelete} style={{ padding: '10px 16px', borderRadius: 999, background: '#ef4444', border: 'none', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer' }}>Confirmer</button>
+                <button onClick={() => setConfirmDelete(false)} style={{ padding: '10px 14px', borderRadius: 999, background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-mid)', fontSize: 13, cursor: 'pointer' }}>Annuler</button>
+              </div>
+            ) : (
+              <button onClick={() => setConfirmDelete(true)} style={{ padding: 12, borderRadius: 999, background: 'transparent', border: '1px solid #ef4444', color: '#ef4444', fontSize: 13.5, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>Supprimer</button>
+            ))}
+            {!confirmDelete && (<>
+              <button onClick={onClose} style={{ flex: 1, padding: 12, borderRadius: 999, background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-mid)', fontSize: 13.5, fontWeight: 600, cursor: 'pointer' }}>Fermer</button>
+              <button onClick={handleSave} disabled={saving || !name.trim()} style={{ flex: 2, padding: 12, borderRadius: 999, background: SPORT_COLOR[sport], border: 'none', color: '#fff', fontWeight: 700, fontSize: 13.5, cursor: saving ? 'wait' : 'pointer', opacity: !name.trim() ? 0.5 : 1 }}>{saving ? '…' : isEdit ? 'Enregistrer' : 'Ajouter'}</button>
+            </>)}
           </div>
         </div>
       </div>

--- a/src/app/calendar/components/types.ts
+++ b/src/app/calendar/components/types.ts
@@ -12,11 +12,17 @@ export interface Race {
   validated?: boolean; validationData?: Record<string, unknown>
 }
 
+// Sports d'un Stage (sans triathlon, avec muscu)
+export type StageSport = 'run' | 'trail' | 'bike' | 'swim' | 'hyrox' | 'rowing' | 'muscu'
+export interface StageSession { sport: StageSport; detail: string; time?: string }
+
 export interface RaceStage {
   id: string; name: string
   startDate: string; endDate: string
   description?: string
-  dailyProgram: { date: string; content: string }[]
+  sports?: StageSport[]
+  // matin/aprem = séances structurées ; content = résumé (rétrocompat lecteurs existants)
+  dailyProgram: { date: string; content: string; matin?: StageSession[]; aprem?: StageSession[] }[]
 }
 
 export interface NutritionItem {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -17,7 +17,7 @@ import DayModal from './components/DayModal'
 import { PageHelp } from '@/onboarding/system/PageHelp'
 import { usePageOnboarding } from '@/onboarding/system/usePageOnboarding'
 import { CALENDAR_ONBOARDING } from '@/onboarding/configs/calendar.config'
-import { Trophy, Briefcase, Heart, LayoutGrid } from 'lucide-react'
+import { Trophy, Briefcase, Heart, LayoutGrid, CalendarDays } from 'lucide-react'
 import { SectionLayout } from '@/components/navigation/SectionLayout'
 type CalView       = 'year' | 'month'
 type TimelineMode  = 'vertical' | 'horizontal'
@@ -696,7 +696,9 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
   const [editRace,    setEditRace]    = useState<Race | null>(null)
   const [prefillDate, setPrefillDate] = useState<string | undefined>(undefined)
   // EventModal: null = closed, {mode,stage?} = open
-  const [eventModal, setEventModal] = useState<{ mode: 'create' | 'edit'; stage?: RaceStage } | null>(null)
+  const [eventModal, setEventModal] = useState<{ mode: 'create' | 'edit'; stage?: RaceStage; initialDate?: string } | null>(null)
+  // Chooser « ajouter un objectif » : date du jour cliqué (null = fermé)
+  const [chooserDate, setChooserDate] = useState<string | null>(null)
   // DayModal
   const [dayModal,   setDayModal]   = useState<{ stage: RaceStage; date: string } | null>(null)
   // Year selector
@@ -798,21 +800,8 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
           </div>
         </div>
 
-        {/* Right: action buttons */}
-        <div style={{ display:'flex',gap:6 }}>
-          <button onClick={() => setEventModal({ mode: 'create' })} style={{
-            padding:'6px 12px',borderRadius:9,fontSize:11,fontWeight:600,cursor:'pointer',
-            background:'rgba(59,130,246,0.10)',border:'1px solid rgba(59,130,246,0.3)',color:'#3b82f6',
-          }}>
-            Événement
-          </button>
-          <button onClick={() => openNewRace()} style={{
-            padding:'6px 12px',borderRadius:9,background:'linear-gradient(135deg,#06B6D4,#5b6fff)',
-            border:'none',color:'#fff',fontSize:11,fontWeight:600,cursor:'pointer',
-          }}>
-            + Course
-          </button>
-        </div>
+        {/* Astuce : l'ajout se fait en cliquant un jour du calendrier */}
+        <span style={{ fontSize:11, color:'var(--text-dim)' }}>Clique sur un jour pour ajouter un objectif</span>
       </div>
 
       {/* Close year picker on outside click */}
@@ -835,7 +824,7 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
           races={yearRaces} stages={yearStages} year={selectedYear}
           onRaceClick={r => { setEditRace(r); setPrefillDate(undefined); setShowRaceModal(true) }}
           onStageDayClick={(s, date) => setDayModal({ stage: s, date })}
-          onDayClick={date => openNewRace(date)}
+          onDayClick={date => setChooserDate(date)}
         />
       )}
 
@@ -845,12 +834,12 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
       {/* Empty state */}
       {yearRaces.length === 0 && yearStages.length === 0 && (
         <div style={{ padding:'32px 20px',textAlign:'center',background:'var(--bg-card)',border:'1px solid var(--border)',borderRadius:14 }}>
-          <p style={{ fontFamily:'Syne,sans-serif',fontSize:15,fontWeight:700,margin:'0 0 6px' }}>Aucune course planifiée en {selectedYear}</p>
-          <button onClick={() => openNewRace()} style={{
+          <p style={{ fontFamily:'Syne,sans-serif',fontSize:15,fontWeight:700,margin:'0 0 6px' }}>Aucun objectif planifié en {selectedYear}</p>
+          <button onClick={() => setChooserDate(new Date().toISOString().split('T')[0])} style={{
             padding:'9px 20px',borderRadius:10,background:'linear-gradient(135deg,#06B6D4,#5b6fff)',
             border:'none',color:'#fff',fontFamily:'Syne,sans-serif',fontWeight:700,fontSize:13,cursor:'pointer',
           }}>
-            + Ajouter une course
+            + Ajouter un objectif
           </button>
         </div>
       )}
@@ -868,6 +857,7 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
         <EventModal
           mode={eventModal.mode}
           initialData={eventModal.stage}
+          initialDate={eventModal.initialDate}
           onClose={() => setEventModal(null)}
           onSave={async (s, dayFiles) => {
             if (eventModal.mode === 'edit' && eventModal.stage) {
@@ -888,7 +878,57 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
           onDeleted={(date) => { deleteStageDayLocal(dayModal.stage.id, date); setDayModal(null) }}
         />
       )}
+
+      {/* Chooser « Ajouter un objectif » — ouvert au clic sur un jour */}
+      {chooserDate && (
+        <ObjectiveChooser
+          date={chooserDate}
+          onClose={() => setChooserDate(null)}
+          onCourse={() => { const d = chooserDate; setChooserDate(null); openNewRace(d) }}
+          onStage={() => { const d = chooserDate; setChooserDate(null); setEventModal({ mode: 'create', initialDate: d }) }}
+        />
+      )}
     </div>
+  )
+}
+
+// ════════════════════════════════════════════════
+// OBJECTIVE CHOOSER — feuille basse : Course ou Stage
+// ════════════════════════════════════════════════
+function ObjectiveChooser({ date, onClose, onCourse, onStage }: {
+  date: string; onClose: () => void; onCourse: () => void; onStage: () => void
+}) {
+  const pretty = new Date(date + 'T12:00:00').toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long' })
+  const card: React.CSSProperties = {
+    flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, padding: '22px 16px',
+    borderRadius: 16, border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer',
+    color: 'var(--text)', fontFamily: 'inherit',
+  }
+  return (
+    <>
+      <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 400, background: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(4px)' }} />
+      <div onClick={e => e.stopPropagation()} style={{
+        position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 401,
+        background: 'var(--bg-card2)', borderRadius: '26px 26px 0 0', padding: '20px 24px calc(24px + env(safe-area-inset-bottom))',
+        boxShadow: '0 -10px 50px rgba(0,0,0,0.22)',
+      }}>
+        <div style={{ width: 40, height: 4, borderRadius: 4, background: 'var(--border-mid)', margin: '0 auto 14px' }} />
+        <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-dim)', margin: 0, textAlign: 'center' }}>Ajouter un objectif</p>
+        <h3 style={{ fontFamily: 'Syne,sans-serif', fontSize: 18, fontWeight: 700, margin: '4px 0 18px', textAlign: 'center', textTransform: 'capitalize' }}>{pretty}</h3>
+        <div style={{ display: 'flex', gap: 12, maxWidth: 460, margin: '0 auto' }}>
+          <button onClick={onCourse} style={card}>
+            <Trophy size={26} color="#06B6D4" />
+            <span style={{ fontWeight: 700, fontSize: 15 }}>Course</span>
+            <span style={{ fontSize: 11.5, color: 'var(--text-dim)', textAlign: 'center' }}>Compétition : course à pied, trail, cyclisme…</span>
+          </button>
+          <button onClick={onStage} style={card}>
+            <CalendarDays size={26} color="#5b6fff" />
+            <span style={{ fontWeight: 700, fontSize: 15 }}>Stage</span>
+            <span style={{ fontSize: 11.5, color: 'var(--text-dim)', textAlign: 'center' }}>Bloc d'entraînement sur plusieurs jours</span>
+          </button>
+        </div>
+      </div>
+    </>
   )
 }
 

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -319,12 +319,20 @@ function useCalendar() {
   }
 
   async function updateRace(r: Race) {
-    await supabase.from('planned_races').update({
+    const { error } = await supabase.from('planned_races').update({
       name: r.name, sport: r.sport, date: r.date, level: r.level,
       goal: r.goal ?? null, strategy: r.strategy ?? null,
+      run_distance: r.runDistance ?? null, tri_distance: r.triDistance ?? null,
+      hyrox_category: r.hyroxCategory ?? null, hyrox_level: r.hyroxLevel ?? null,
+      hyrox_gender: r.hyroxGender ?? null, goal_time: r.goalTime ?? null,
+      goal_swim_time: r.goalSwimTime ?? null, goal_bike_time: r.goalBikeTime ?? null,
+      goal_run_time: r.goalRunTime ?? null,
+      status: r.status ?? 'upcoming', distance: r.distance ?? null,
+      performance_data: r.performanceData ?? {}, notes: r.notes ?? null,
       validated: r.validated ?? false, validation_data: r.validationData ?? {},
       updated_at: new Date().toISOString(),
     }).eq('id', r.id)
+    if (error) { console.error('[updateRace] update error', error); throw error }
     setRaces(p => p.map(x => x.id === r.id ? r : x))
   }
 

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -10,8 +10,33 @@ import AnnualView from './components/AnnualView'
 import AppleCalendarView from './components/AppleCalendarView'
 import RaceModal from './components/RaceModal'
 import EventModal from './components/EventModal'
-import type { RaceStage, NutritionItem } from './components/types'
+import type { RaceStage, NutritionItem, StageSport } from './components/types'
 import { sanitizeFileName } from '@/lib/utils'
+
+// Sérialisation du programme de stage dans le JSONB daily_program (zéro migration).
+// Nouveau format : { sports, days } ; rétrocompat : ancien format = tableau de jours.
+function parseStageProgram(raw: unknown): { sports: StageSport[]; days: RaceStage['dailyProgram'] } {
+  if (Array.isArray(raw)) return { sports: [], days: raw as RaceStage['dailyProgram'] }
+  if (raw && typeof raw === 'object') {
+    const o = raw as { sports?: StageSport[]; days?: RaceStage['dailyProgram'] }
+    return { sports: o.sports ?? [], days: o.days ?? [] }
+  }
+  return { sports: [], days: [] }
+}
+function serializeStageProgram(s: { sports?: StageSport[]; dailyProgram: RaceStage['dailyProgram'] }) {
+  return { sports: s.sports ?? [], days: s.dailyProgram }
+}
+const mondayOf = (dateStr: string): string => {
+  const d = new Date(dateStr + 'T12:00:00'); const dow = (d.getDay() + 6) % 7
+  d.setDate(d.getDate() - dow); return d.toISOString().split('T')[0]
+}
+const dowOf = (dateStr: string): number => (new Date(dateStr + 'T12:00:00').getDay() + 6) % 7
+const STAGE_PLANNING_SPORT: Record<StageSport, string> = {
+  run: 'run', trail: 'run', bike: 'bike', swim: 'swim', hyrox: 'hyrox', rowing: 'rowing', muscu: 'gym',
+}
+const STAGE_SPORT_LABEL: Record<StageSport, string> = {
+  run: 'Course à pied', trail: 'Trail', bike: 'Cyclisme', swim: 'Natation', hyrox: 'Hyrox', rowing: 'Aviron', muscu: 'Muscu',
+}
 import ClockView, { type ClockEvent } from './components/ClockView'
 import DayModal from './components/DayModal'
 import { PageHelp } from '@/onboarding/system/PageHelp'
@@ -141,12 +166,16 @@ function useCalendar() {
       notes: x.notes as string | undefined,
     })))
 
-    setRaceStages((rs.data ?? []).map((x: Record<string, unknown>): RaceStage => ({
-      id: x.id as string, name: x.name as string,
-      startDate: x.start_date as string, endDate: x.end_date as string,
-      description: x.description as string | undefined,
-      dailyProgram: (x.daily_program as { date: string; content: string }[]) ?? [],
-    })))
+    setRaceStages((rs.data ?? []).map((x: Record<string, unknown>): RaceStage => {
+      const prog = parseStageProgram(x.daily_program)
+      return {
+        id: x.id as string, name: x.name as string,
+        startDate: x.start_date as string, endDate: x.end_date as string,
+        description: x.description as string | undefined,
+        sports: prog.sports,
+        dailyProgram: prog.days,
+      }
+    }))
 
     setEventTypes((et.data ?? []).map((x: Record<string, unknown>): CalEventType => ({
       id: x.id as string, name: x.name as string, color: x.color as string,
@@ -229,7 +258,7 @@ function useCalendar() {
     console.log('[addRaceStage] inserting event', s.name, 'dayFiles:', dayFiles.length)
     const { data, error } = await supabase.from('race_events').insert({
       user_id: user.id, name: s.name, start_date: s.startDate, end_date: s.endDate,
-      description: s.description ?? null, daily_program: s.dailyProgram,
+      description: s.description ?? null, daily_program: serializeStageProgram(s),
     }).select().single()
     if (error) { console.error('[addRaceStage] insert error', error); return }
     if (!data) { console.error('[addRaceStage] no data returned'); return }
@@ -267,7 +296,7 @@ function useCalendar() {
     if (!updatedProgram.find(d => d.date === date)) {
       updatedProgram.push({ date, content })
     }
-    await supabase.from('race_events').update({ daily_program: updatedProgram }).eq('id', stageId)
+    await supabase.from('race_events').update({ daily_program: serializeStageProgram({ sports: stage.sports, dailyProgram: updatedProgram }) }).eq('id', stageId)
     setRaceStages(p => p.map(s => s.id === stageId ? { ...s, dailyProgram: updatedProgram } : s))
 
     if (file) {
@@ -292,7 +321,7 @@ function useCalendar() {
     console.log('[updateRaceStage] updating event', s.id, s.name, 'dayFiles:', dayFiles.length)
     const { error: upErr } = await supabase.from('race_events').update({
       name: s.name, start_date: s.startDate, end_date: s.endDate,
-      description: s.description ?? null, daily_program: s.dailyProgram,
+      description: s.description ?? null, daily_program: serializeStageProgram(s),
       updated_at: new Date().toISOString(),
     }).eq('id', s.id)
     if (upErr) console.error('[updateRaceStage] update error', upErr)
@@ -401,10 +430,38 @@ function useCalendar() {
     }))
   }
 
+  async function deleteRaceStage(id: string) {
+    await supabase.from('race_events').delete().eq('id', id)
+    setRaceStages(p => p.filter(s => s.id !== id))
+  }
+
+  // Push auto des séances structurées d'un stage dans le planning (au save / create).
+  async function addStageSessionsToPlanning(stage: RaceStage) {
+    const { data: { user } } = await supabase.auth.getUser(); if (!user) return
+    const rows: Record<string, unknown>[] = []
+    for (const day of stage.dailyProgram) {
+      for (const slot of ['matin', 'aprem'] as const) {
+        for (const ses of day[slot] ?? []) {
+          if (!ses.detail?.trim() && !ses.sport) continue
+          rows.push({
+            user_id: user.id, week_start: mondayOf(day.date), day_index: dowOf(day.date),
+            sport: STAGE_PLANNING_SPORT[ses.sport] ?? 'run',
+            title: `${stage.name} — ${ses.detail?.trim() || STAGE_SPORT_LABEL[ses.sport]}`,
+            time: ses.time || (slot === 'matin' ? '09:00' : '15:00'),
+            duration_min: 60, status: 'planned', notes: ses.detail?.trim() || null,
+            blocks: [], validation_data: {},
+          })
+        }
+      }
+    }
+    if (rows.length) await supabase.from('planned_sessions').insert(rows)
+  }
+
   return {
     races, raceStages, eventTypes, events, loading,
     addRace, addRaceWithFiles, updateRace, deleteRace, markCompleted,
-    addRaceStage, updateRaceStage, saveStageDayContent, patchStageDayLocal, deleteStageDayLocal,
+    addRaceStage, updateRaceStage, deleteRaceStage, addStageSessionsToPlanning,
+    saveStageDayContent, patchStageDayLocal, deleteStageDayLocal,
     addEventType, updateEventType, deleteEventType,
     addEvent, updateEvent, deleteEvent,
   }
@@ -680,13 +737,15 @@ function RaceEventModal({ month, day, year, onClose, onSave }: {
 // ════════════════════════════════════════════════
 // RACE TAB — new component-based implementation
 // ════════════════════════════════════════════════
-function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, markCompleted, addRaceStage, updateRaceStage, patchStageDayLocal, deleteStageDayLocal }: {
+function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, markCompleted, addRaceStage, updateRaceStage, deleteRaceStage, addStageSessionsToPlanning, patchStageDayLocal, deleteStageDayLocal }: {
   races: Race[]; raceStages: RaceStage[]
   addRaceWithFiles: (r: Omit<Race, 'id' | 'validated' | 'validationData'>, files: File[], fb?: File[], fr?: File[]) => Promise<void>
   updateRace: (r: Race) => void; deleteRace: (id: string) => void
   markCompleted: (id: string) => void
   addRaceStage: (s: Omit<RaceStage, 'id'>, dayFiles: { date: string; file: File }[]) => Promise<void>
   updateRaceStage: (s: RaceStage, dayFiles: { date: string; file: File }[]) => Promise<void>
+  deleteRaceStage: (id: string) => void
+  addStageSessionsToPlanning: (s: RaceStage) => Promise<void>
   patchStageDayLocal: (stageId: string, date: string, content: string) => void
   deleteStageDayLocal: (stageId: string, date: string) => void
 }) {
@@ -859,11 +918,16 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
           initialData={eventModal.stage}
           initialDate={eventModal.initialDate}
           onClose={() => setEventModal(null)}
+          onDelete={eventModal.mode === 'edit' && eventModal.stage
+            ? () => { deleteRaceStage(eventModal.stage!.id); setEventModal(null) }
+            : undefined}
           onSave={async (s, dayFiles) => {
             if (eventModal.mode === 'edit' && eventModal.stage) {
               await updateRaceStage({ ...eventModal.stage, ...s }, dayFiles)
             } else {
               await addRaceStage(s, dayFiles)
+              // Push auto des séances du stage dans le planning (création).
+              await addStageSessionsToPlanning({ ...s, id: 'tmp' })
             }
             setEventModal(null)
           }}
@@ -1490,7 +1554,7 @@ function AllTab({ races, eventTypes, events }: { races: Race[]; eventTypes: CalE
 // PAGE
 // ════════════════════════════════════════════════
 export default function CalendarPage() {
-  const { races, raceStages, eventTypes, events, loading, addRaceWithFiles, updateRace, deleteRace, markCompleted, addRaceStage, updateRaceStage, patchStageDayLocal, deleteStageDayLocal, addEventType, updateEventType, deleteEventType, addEvent, updateEvent, deleteEvent } = useCalendar()
+  const { races, raceStages, eventTypes, events, loading, addRaceWithFiles, updateRace, deleteRace, markCompleted, addRaceStage, updateRaceStage, deleteRaceStage, addStageSessionsToPlanning, patchStageDayLocal, deleteStageDayLocal, addEventType, updateEventType, deleteEventType, addEvent, updateEvent, deleteEvent } = useCalendar()
   const { show, dismiss, reopen } = usePageOnboarding(CALENDAR_ONBOARDING.pageId, CALENDAR_ONBOARDING.version)
 
   const aiContext = {
@@ -1529,7 +1593,7 @@ export default function CalendarPage() {
       <SectionLayout
         header={header}
         sections={[
-          { id:'race',  label:'Course', subtitle:'Compétitions',  icon:Trophy,     content: loading ? loader : <RaceTab races={races} raceStages={raceStages} addRaceWithFiles={addRaceWithFiles} updateRace={updateRace} deleteRace={deleteRace} markCompleted={markCompleted} addRaceStage={addRaceStage} updateRaceStage={updateRaceStage} patchStageDayLocal={patchStageDayLocal} deleteStageDayLocal={deleteStageDayLocal}/> },
+          { id:'race',  label:'Course', subtitle:'Compétitions',  icon:Trophy,     content: loading ? loader : <RaceTab races={races} raceStages={raceStages} addRaceWithFiles={addRaceWithFiles} updateRace={updateRace} deleteRace={deleteRace} markCompleted={markCompleted} addRaceStage={addRaceStage} updateRaceStage={updateRaceStage} deleteRaceStage={deleteRaceStage} addStageSessionsToPlanning={addStageSessionsToPlanning} patchStageDayLocal={patchStageDayLocal} deleteStageDayLocal={deleteStageDayLocal}/> },
           { id:'pro',   label:'Pro',    subtitle:'Professionnel',  icon:Briefcase,  content: loading ? loader : <CategoryTab category="pro"   eventTypes={eventTypes} events={events} addEventType={addEventType} updateEventType={updateEventType} deleteEventType={deleteEventType} addEvent={addEvent} deleteEvent={deleteEvent}/> },
           { id:'perso', label:'Perso',  subtitle:'Personnel',      icon:Heart,      content: loading ? loader : <CategoryTab category="perso" eventTypes={eventTypes} events={events} addEventType={addEventType} updateEventType={updateEventType} deleteEventType={deleteEventType} addEvent={addEvent} deleteEvent={deleteEvent}/> },
           { id:'all',   label:'Tout',   subtitle:'Vue globale',    icon:LayoutGrid, content: loading ? loader : <AllTab races={races} eventTypes={eventTypes} events={events}/> },

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -861,6 +861,7 @@ function RaceTab({ races, raceStages, addRaceWithFiles, updateRace, deleteRace, 
           initialDate={prefillDate}
           onClose={closeRaceModal}
           onSave={handleSaveRace}
+          onDelete={editRace ? () => { deleteRace(editRace.id); closeRaceModal() } : undefined}
         />
       )}
       {eventModal && (

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { SportTabs } from '@/components/ui/SportTabs'
 import { TabbedPageLayout, type PageTab } from '@/components/ui/TabbedPageLayout'
 import { Dumbbell, Library } from 'lucide-react'
+import { EXERCISE_DATABASE, type ExoCategory } from '@/components/planning/exercises'
 import { useTrainingZones } from '@/hooks/useTrainingZones'
 import { usePlanning } from '@/hooks/usePlanning'
 import { PageHelp } from '@/onboarding/system/PageHelp'
@@ -55,10 +56,12 @@ interface EnduranceBlock {
 }
 
 // — Natation
+type Stroke = 'crawl' | 'dos' | 'brasse' | 'papillon'
 interface SwimSet {
   id: string; reps: number; distanceM: number
   zone: Zone; restSec: number; note?: string
   targetPacePer100m?: string   // "1:35" format
+  stroke?: Stroke              // nage (4 nages) — défaut crawl
 }
 
 // — Hyrox
@@ -532,28 +535,6 @@ function IntensityProfile({
 }
 
 // ══════════════════════════════════════════════════════════════════
-// EXERCISE DATABASE
-// ══════════════════════════════════════════════════════════════════
-const EXERCISE_DB = [
-  // Push
-  'Développé couché','Développé incliné','Développé militaire','Dips','Pompes',
-  'Écarté poulie haute','Extensions triceps',
-  // Pull
-  'Tractions pronation','Tractions supination','Tractions lestées','Rowing barre',
-  'Rowing haltère','Tirage vertical','Curl biceps barre','Curl marteau',
-  // Legs
-  'Squat barre','Squat gobelet','Fentes','Presse à cuisses','Leg extension',
-  'Leg curl couché','Hip thrust','Soulevé de terre','Soulevé de terre roumain',
-  'Mollets debout',
-  // Core / Gainage
-  'Gainage frontal','Gainage latéral','Crunchs','Relevés de jambes','Russian twist',
-  'Roue abdominale','Bird dog',
-  // Hyrox
-  'Wall Balls','Farmer Carry','Sled Push','Sled Pull','SkiErg','Burpee Broad Jump',
-  'Rowing ergomètre','Sandbag Lunges',
-]
-
-// ══════════════════════════════════════════════════════════════════
 // MUSCU BUILDER
 // ══════════════════════════════════════════════════════════════════
 function MusculaireBuilder({ data, onChange }: {
@@ -635,11 +616,7 @@ function MusculaireBuilder({ data, onChange }: {
                         style={{ background:'none', border:'none', color:idx===exs.length-1?'var(--border)':'var(--text-dim)', cursor:idx===exs.length-1?'default':'pointer', padding:0, lineHeight:1, fontSize:13 }}>&#8595;</button>
                     </div>
                     <span style={{ fontSize:11, color:'var(--text-dim)', fontFamily:'DM Mono,monospace', width:16, textAlign:'center', flexShrink:0 }}>{idx+1}</span>
-                    <input list={`exo-list-${ex.id}`} value={ex.name} onChange={e => updExercise(ex.id, { name:e.target.value })}
-                      placeholder="Exercice..." style={{ ...inp }}/>
-                    <datalist id={`exo-list-${ex.id}`}>
-                      {EXERCISE_DB.map(n => <option key={n} value={n}/>)}
-                    </datalist>
+                    <ExoPicker value={ex.name} onPick={name => updExercise(ex.id, { name })}/>
                     <button onClick={() => rmExercise(ex.id)}
                       style={{ background:'none', border:'none', color:'var(--text-dim)', cursor:'pointer', fontSize:16, padding:'4px', lineHeight:1, flexShrink:0 }}>×</button>
                   </div>
@@ -681,9 +658,82 @@ function MusculaireBuilder({ data, onChange }: {
 }
 
 // ══════════════════════════════════════════════════════════════════
-// SWIM DISTANCES
+// SWIM DISTANCES + NAGES (4 nages)
 // ══════════════════════════════════════════════════════════════════
 const SWIM_DISTANCES = [25, 50, 75, 100, 150, 200, 300, 400, 500, 600, 800, 1000, 1500, 2000]
+const STROKES: { id: Stroke; label: string }[] = [
+  { id:'crawl',    label:'Crawl' },
+  { id:'dos',      label:'Dos' },
+  { id:'brasse',   label:'Brasse' },
+  { id:'papillon', label:'Papillon' },
+]
+
+// ══════════════════════════════════════════════════════════════════
+// MUSCU — catégories de la bibliothèque d'exos préenregistrés
+// (Push · Pull · Legs · Mixte · Core/Abdos), depuis EXERCISE_DATABASE
+// ══════════════════════════════════════════════════════════════════
+const MUSCU_CATS: { cat: ExoCategory; label: string }[] = [
+  { cat:'push',  label:'Push' },
+  { cat:'pull',  label:'Pull' },
+  { cat:'legs',  label:'Legs' },
+  { cat:'mixte', label:'Mixte' },
+  { cat:'abdos', label:'Core / Abdos' },
+]
+
+// Sélecteur d'exercice : liste préenregistrée triée par catégorie + création libre.
+function ExoPicker({ value, onPick }: { value: string; onPick: (name: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [custom, setCustom] = useState('')
+  const wrapRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    function onDoc(e: MouseEvent) { if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false) }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  const fld: React.CSSProperties = { flex:1, minWidth:0, borderRadius:8, border:'1px solid var(--border)', background:'var(--bg-card2)', color: value ? 'var(--text-main)' : 'var(--text-dim)', padding:'7px 10px', fontFamily:'DM Sans,sans-serif', fontSize:13, textAlign:'left' as const, cursor:'pointer', whiteSpace:'nowrap' as const, overflow:'hidden', textOverflow:'ellipsis' }
+
+  function add(name: string) { const n = name.trim(); if (!n) return; onPick(n); setCustom(''); setOpen(false) }
+
+  return (
+    <div ref={wrapRef} style={{ position:'relative', flex:1, minWidth:0 }}>
+      <button type="button" onClick={() => setOpen(o => !o)} style={fld}>{value || 'Choisir un exercice…'}</button>
+      {open && (
+        <div style={{ position:'absolute', zIndex:60, top:'calc(100% + 4px)', left:0, right:0, maxHeight:300, overflowY:'auto',
+          background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:12, boxShadow:'0 8px 28px rgba(0,0,0,0.32)', padding:8 }}>
+          {MUSCU_CATS.map(({ cat, label }) => {
+            const items = EXERCISE_DATABASE.filter(e => e.category === cat)
+            if (!items.length) return null
+            return (
+              <div key={cat} style={{ marginBottom:6 }}>
+                <p style={{ fontSize:9, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.08em', color:'var(--text-dim)', margin:'4px 6px' }}>{label}</p>
+                {items.map(e => (
+                  <button key={e.id} type="button" onClick={() => add(e.name)}
+                    style={{ display:'block', width:'100%', textAlign:'left', padding:'6px 8px', borderRadius:8, border:'none', background:'transparent', color:'var(--text-main)', fontFamily:'DM Sans,sans-serif', fontSize:12, cursor:'pointer' }}
+                    onMouseEnter={ev => (ev.currentTarget.style.background = 'var(--bg-card2)')}
+                    onMouseLeave={ev => (ev.currentTarget.style.background = 'transparent')}>
+                    {e.name}
+                  </button>
+                ))}
+              </div>
+            )
+          })}
+          {/* Créer un exo */}
+          <div style={{ borderTop:'1px solid var(--border)', marginTop:4, paddingTop:8, display:'flex', gap:6 }}>
+            <input value={custom} onChange={e => setCustom(e.target.value)} placeholder="Créer un exo…"
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(custom) } }}
+              style={{ flex:1, minWidth:0, borderRadius:8, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text-main)', padding:'6px 8px', fontFamily:'DM Sans,sans-serif', fontSize:12, boxSizing:'border-box' as const }}/>
+            <button type="button" onClick={() => add(custom)}
+              style={{ padding:'6px 12px', borderRadius:8, border:'none', background:'#5b6fff', color:'#fff', fontFamily:'DM Sans,sans-serif', fontSize:12, fontWeight:600, cursor:'pointer', flexShrink:0 }}>
+              Ajouter
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
 
 // ══════════════════════════════════════════════════════════════════
 // ENDURANCE BUILDER (Running / Vélo / Aviron / Triathlon)
@@ -770,6 +820,32 @@ function EnduranceBuilder({
             Profil d'intensité · {totalMin}min total
           </p>
           <IntensityProfile blocks={blocks} sport={sport}/>
+          {/* Bulles réordonnables — glisser pour changer l'ordre des blocs */}
+          {blocks.length > 1 && (
+            <>
+              <p style={{ fontSize:9, color:'var(--text-dim)', margin:'10px 0 6px' }}>Glisse les bulles pour réordonner les blocs</p>
+              <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
+                {blocks.map((b, idx) => (
+                  <div key={b.id}
+                    draggable
+                    onDragStart={() => onDragStart(idx)}
+                    onDragOver={e => onDragOver(e, idx)}
+                    onDrop={() => onDrop(idx)}
+                    onDragEnd={() => setDragOverIdx(null)}
+                    style={{
+                      display:'flex', alignItems:'center', gap:6, padding:'5px 10px', borderRadius:99, cursor:'grab',
+                      background: dragOverIdx === idx ? `${color}18` : 'var(--bg-card)',
+                      border:`1px solid ${dragOverIdx === idx ? color : 'var(--border)'}`,
+                      borderLeft:`3px solid ${ZONE_COLOR[b.zone]}`,
+                    }}>
+                    <span style={{ fontSize:10, color:'var(--text-dim)', fontFamily:'DM Mono,monospace' }}>{idx+1}</span>
+                    <span style={{ fontSize:11, fontWeight:600, color:'var(--text-main)', maxWidth:130, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{b.name || 'Bloc'}</span>
+                    <span style={{ width:7, height:7, borderRadius:'50%', background:ZONE_COLOR[b.zone], flexShrink:0 }}/>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </div>
       )}
 
@@ -956,6 +1032,12 @@ function NatationBuilder({ data, onChange }: { data: NatationSession; onChange:(
             <span style={{ fontFamily:'DM Mono,monospace', fontSize:12, color:'var(--text-dim)', width:18, flexShrink:0, paddingBottom:8 }}>{idx+1}</span>
             <NumInput label="Reps" value={s.reps} onChange={v=>updSet(s.id,{reps:v})} min={1} max={50}/>
             <span style={{ fontSize:18, color:'var(--text-dim)', paddingBottom:6, fontWeight:300 }}>×</span>
+            <div>
+              <label style={{ fontSize:10, color:'var(--text-dim)', display:'block', marginBottom:3 }}>Nage</label>
+              <select value={s.stroke ?? 'crawl'} onChange={e=>updSet(s.id,{stroke:e.target.value as Stroke})} style={sel}>
+                {STROKES.map(st=><option key={st.id} value={st.id}>{st.label}</option>)}
+              </select>
+            </div>
             <div>
               <label style={{ fontSize:10, color:'var(--text-dim)', display:'block', marginBottom:3 }}>Distance</label>
               <select value={s.distanceM} onChange={e=>updSet(s.id,{distanceM:+e.target.value})}
@@ -1443,10 +1525,11 @@ const CYCLING_SUB: { id: CyclingSub; label: string }[] = [
 // ══════════════════════════════════════════════════════════════════
 // BUILD MODE — full session form + sport builder
 // ══════════════════════════════════════════════════════════════════
-function BuildMode({ initial, onSave, onCancel }: {
+function BuildMode({ initial, onSave, onCancel, onDelete }: {
   initial?: SessionTemplate
   onSave: (t: SessionTemplate) => void
   onCancel: () => void
+  onDelete?: () => void
 }) {
   const { addSession } = usePlanning()
   const { zones: trainingZones } = useTrainingZones()
@@ -1462,6 +1545,12 @@ function BuildMode({ initial, onSave, onCancel }: {
   const [planDate,     setPlanDate]     = useState('')
   const [planTime,     setPlanTime]     = useState('09:00')
   const [planSuccess,  setPlanSuccess]  = useState(false)
+  // Mode de construction : manuel ou génération IA (réutilise /api/session-builder)
+  const [buildMode,   setBuildMode]   = useState<'manuel'|'ia'>('manuel')
+  const [iaText,      setIaText]      = useState('')
+  const [iaLoading,   setIaLoading]   = useState(false)
+  const [iaError,     setIaError]     = useState<string|null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
 
   // Reset session types when sport changes
   useEffect(() => { setSessionTypes([]) }, [sport])
@@ -1500,10 +1589,92 @@ function BuildMode({ initial, onSave, onCancel }: {
     onSave(t)
   }
 
+  // ── Génération IA : décris la séance → l'IA construit blocs + profil ──
+  async function generateIA() {
+    if (!iaText.trim() || iaLoading) return
+    setIaLoading(true); setIaError(null)
+    try {
+      const profil = {
+        ftp: trainingZones.bike?.ftp_watts ?? undefined,
+        sl1: trainingZones.run?.sl1 || undefined,
+        sl2: trainingZones.run?.sl2 || undefined,
+      }
+      const typesSeance = sessionTypes.length > 0 ? sessionTypes : [SESSION_TYPES[sport]?.[0] ?? 'Mixte']
+      const res = await fetch('/api/session-builder', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sport, typesSeance, descriptionLibre: iaText.trim(), profil }),
+      })
+      const data = await res.json() as { session?: SBLibRow & { intensite: string }; error?: string }
+      if (data.error || !data.session) { setIaError(data.error || "L'IA n'a pas pu générer la séance."); return }
+      const s = data.session
+      const tmpl = sbRowToTemplate({
+        id: uid(), nom: s.nom, sport: s.sport, type_seance: s.type_seance,
+        duree_estimee: s.duree_estimee, intensite: s.intensite, tss_estime: s.tss_estime ?? null,
+        rpe_cible: s.rpe_cible ?? null, tags: s.tags, description: s.description, blocs: s.blocs,
+      })
+      if (!tmpl) { setIaError('Sport non reconnu dans la séance générée.'); return }
+      setSport(tmpl.sport)
+      setName(tmpl.name)
+      setDuration(tmpl.durationMin)
+      setIntensity(tmpl.intensity)
+      if (tmpl.typeSeance?.length) setSessionTypes(tmpl.typeSeance)
+      if (tmpl.tags?.length) setTagsStr(tmpl.tags.join(', '))
+      if (tmpl.notes) setNotes(tmpl.notes)
+      if (typeof tmpl.rpe === 'number') setRpeTarget(tmpl.rpe)
+      if (tmpl.endurance) setEndur(tmpl.endurance)
+      setBuildMode('manuel')   // bascule sur le builder rempli pour ajuster
+    } catch (e) {
+      setIaError(e instanceof Error ? e.message : 'Erreur réseau')
+    } finally { setIaLoading(false) }
+  }
+
   const inp: React.CSSProperties = { width:'100%', borderRadius:10, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text-main)', padding:'9px 12px', fontFamily:'DM Sans,sans-serif', fontSize:13, boxSizing:'border-box' as const }
 
   return (
     <div>
+      {/* Toggle Manuel / IA */}
+      <div style={{ display:'flex', justifyContent:'flex-end', marginBottom:12 }}>
+        <div style={{ display:'inline-flex', gap:4, background:'var(--bg-card2)', border:'1px solid var(--border)', borderRadius:99, padding:3 }}>
+          {(['manuel','ia'] as const).map(m => (
+            <button key={m} onClick={() => setBuildMode(m)}
+              style={{ padding:'6px 18px', borderRadius:99, border:'none', cursor:'pointer', fontFamily:'DM Sans,sans-serif', fontSize:12, fontWeight:600,
+                background: buildMode===m ? (m==='ia' ? '#5b6fff' : 'var(--bg-card)') : 'transparent',
+                color: buildMode===m ? (m==='ia' ? '#fff' : 'var(--text-main)') : 'var(--text-dim)' }}>
+              {m==='manuel' ? 'Manuel' : '✨ IA'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Génération IA */}
+      {buildMode === 'ia' && (
+        <SectionCard>
+          <SectionHeader label="Assistant IA" title="Décris ta séance" color="#5b6fff"/>
+          <div style={{ display:'flex', gap:8, flexWrap:'wrap', marginBottom:12 }}>
+            {SPORTS.map(s => (
+              <button key={s.id} onClick={()=>setSport(s.id)}
+                style={{ padding:'7px 14px', borderRadius:12, border:`1px solid ${sport===s.id?s.color:'var(--border)'}`,
+                  background:sport===s.id?`${s.color}15`:'transparent', color:sport===s.id?s.color:'var(--text-dim)',
+                  fontFamily:'DM Sans,sans-serif', fontSize:12, fontWeight:600, cursor:'pointer' }}>
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <textarea value={iaText} onChange={e=>setIaText(e.target.value)} rows={4}
+            placeholder="Ex : 5×5min à PMA (105–110% FTP), 5min de récup entre chaque, 15min d'échauffement Z2 puis 10min de retour au calme."
+            style={{ ...inp, resize:'none' as const, lineHeight:1.5 }}/>
+          {iaError && <p style={{ color:'#ef4444', fontSize:12, margin:'8px 0 0' }}>{iaError}</p>}
+          <button onClick={generateIA} disabled={iaLoading || !iaText.trim()}
+            style={{ width:'100%', marginTop:12, padding:'12px 0', borderRadius:10, border:'none',
+              background: iaLoading || !iaText.trim() ? 'var(--bg-card2)' : 'linear-gradient(135deg,#5b6fff,#06B6D4)',
+              color: iaLoading || !iaText.trim() ? 'var(--text-dim)' : '#fff',
+              fontFamily:'Syne,sans-serif', fontSize:14, fontWeight:700, cursor: iaLoading || !iaText.trim() ? 'not-allowed' : 'pointer' }}>
+            {iaLoading ? 'Génération…' : 'Générer la séance'}
+          </button>
+        </SectionCard>
+      )}
+
+      {buildMode === 'manuel' && (<>
       {/* Header */}
       <SectionCard>
         <div style={{ display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom:20 }}>
@@ -1757,17 +1928,38 @@ function BuildMode({ initial, onSave, onCancel }: {
         </button>
       </SectionCard>
 
-      {/* Save */}
-      <div style={{ display:'flex', gap:10 }}>
-        <button onClick={onCancel}
-          style={{ flex:1, padding:'12px 0', borderRadius:12, border:'1px solid var(--border)', background:'transparent', color:'var(--text-mid)', fontFamily:'DM Sans,sans-serif', fontSize:14, cursor:'pointer' }}>
-          Annuler
-        </button>
-        <button onClick={save}
-          style={{ flex:3, padding:'12px 0', borderRadius:6, border:'none', background:'#1B6EF3', color:'#fff', fontFamily:'Syne,sans-serif', fontSize:14, fontWeight:700, cursor:'pointer', boxShadow:'0 4px 20px rgba(27,110,243,0.30)' }}>
-          Enregistrer la seance
-        </button>
+      {/* Save / Supprimer */}
+      <div style={{ display:'flex', gap:10, alignItems:'center' }}>
+        {onDelete && (confirmDelete ? (
+          <div style={{ display:'flex', gap:8, alignItems:'center', flex:1, flexWrap:'wrap' }}>
+            <span style={{ fontSize:12, color:'#ef4444', fontFamily:'DM Sans,sans-serif', fontWeight:600 }}>Supprimer cette séance ?</span>
+            <button onClick={onDelete}
+              style={{ padding:'10px 16px', borderRadius:8, border:'none', background:'#ef4444', color:'#fff', fontFamily:'DM Sans,sans-serif', fontSize:13, fontWeight:700, cursor:'pointer' }}>
+              Confirmer la suppression
+            </button>
+            <button onClick={()=>setConfirmDelete(false)}
+              style={{ padding:'10px 14px', borderRadius:8, border:'1px solid var(--border)', background:'transparent', color:'var(--text-mid)', fontFamily:'DM Sans,sans-serif', fontSize:13, cursor:'pointer' }}>
+              Annuler
+            </button>
+          </div>
+        ) : (
+          <button onClick={()=>setConfirmDelete(true)}
+            style={{ padding:'12px 16px', borderRadius:12, border:'1px solid #ef4444', background:'transparent', color:'#ef4444', fontFamily:'DM Sans,sans-serif', fontSize:14, fontWeight:600, cursor:'pointer', flexShrink:0 }}>
+            Supprimer
+          </button>
+        ))}
+        {!confirmDelete && (<>
+          <button onClick={onCancel}
+            style={{ flex:1, padding:'12px 0', borderRadius:12, border:'1px solid var(--border)', background:'transparent', color:'var(--text-mid)', fontFamily:'DM Sans,sans-serif', fontSize:14, cursor:'pointer' }}>
+            Fermer
+          </button>
+          <button onClick={save}
+            style={{ flex:3, padding:'12px 0', borderRadius:6, border:'none', background:'#1B6EF3', color:'#fff', fontFamily:'Syne,sans-serif', fontSize:14, fontWeight:700, cursor:'pointer', boxShadow:'0 4px 20px rgba(27,110,243,0.30)' }}>
+            Enregistrer la seance
+          </button>
+        </>)}
       </div>
+      </>)}
     </div>
   )
 }
@@ -2196,6 +2388,7 @@ export default function SessionPage() {
                 initial={editTarget}
                 onSave={handleSave}
                 onCancel={()=>setMode('library')}
+                onDelete={editTarget ? () => { void handleDelete(editTarget); setMode('library') } : undefined}
               />
             )}
 

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -5,6 +5,8 @@ export const dynamic = 'force-dynamic'
 import { useState, useEffect, useRef, useCallback } from 'react'
 // import { createClient } from '@/lib/supabase/client'
 import { SportTabs } from '@/components/ui/SportTabs'
+import { TabbedPageLayout, type PageTab } from '@/components/ui/TabbedPageLayout'
+import { Dumbbell, Library } from 'lucide-react'
 import { useTrainingZones } from '@/hooks/useTrainingZones'
 import { usePlanning } from '@/hooks/usePlanning'
 import { PageHelp } from '@/onboarding/system/PageHelp'
@@ -15,6 +17,7 @@ import { SESSION_ONBOARDING } from '@/onboarding/configs/session.config'
 // TYPES
 // ══════════════════════════════════════════════════════════════════
 type Sport      = 'muscu' | 'running' | 'velo' | 'natation' | 'hyrox' | 'aviron' | 'triathlon'
+type TopTab     = 'builder' | 'biblio'   // onglets de page : Builder · Bibliothèque
 type PageMode   = 'library' | 'build' | 'execute'
 type Zone       = 1 | 2 | 3 | 4 | 5
 type Intensity  = 'low' | 'moderate' | 'high' | 'max'
@@ -1862,8 +1865,8 @@ function LibraryMode({ templates, onNew, onEdit, onStart, onDelete }: {
         {/* Header */}
         <div style={{ display:'flex', justifyContent:'space-between', alignItems:'flex-start', marginBottom:18, flexWrap:'wrap', gap:10 }}>
           <div>
-            <p style={{ fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.1em', color:'var(--text-dim)', margin:0 }}>Bibliothèque</p>
-            <h2 style={{ fontFamily:'Syne,sans-serif', fontSize:20, fontWeight:700, margin:'4px 0 0' }}>Séances types</h2>
+            <p style={{ fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.1em', color:'var(--text-dim)', margin:0 }}>Builder</p>
+            <h2 style={{ fontFamily:'Syne,sans-serif', fontSize:20, fontWeight:700, margin:'4px 0 0' }}>Mes séances en réserve</h2>
           </div>
           <button onClick={onNew}
             style={{ padding:'9px 20px', borderRadius:6, border:'none', background:'#1B6EF3',
@@ -2044,8 +2047,62 @@ function sbRowToTemplate(row: SBLibRow): SessionTemplate | null {
 // ══════════════════════════════════════════════════════════════════
 // PAGE
 // ══════════════════════════════════════════════════════════════════
+// ══════════════════════════════════════════════════════════════════
+// BIBLIOTHÈQUE — référentiel de séances & exos types (objectif, déroulé,
+// quand la programmer). Coquille stylée ; le contenu est ajouté ensuite.
+// ══════════════════════════════════════════════════════════════════
+const FD = 'var(--font-display)', FB = 'var(--font-body)'
+
+function BibliothequeTab() {
+  const [sport, setSport] = useState<Sport | 'all'>('all')
+
+  return (
+    <div>
+      {/* Accroche éditoriale */}
+      <p style={{ fontFamily: FD, fontSize: 17, fontWeight: 500, color: 'var(--text)', margin: '0 0 4px', lineHeight: 1.35 }}>
+        Des séances et exercices types, expliqués.
+      </p>
+      <p style={{ fontFamily: FB, fontSize: 13, color: 'var(--text-dim)', margin: '0 0 20px', maxWidth: 560, lineHeight: 1.5 }}>
+        Pour chaque type de séance : son objectif, son déroulé détaillé, et le bon moment pour la programmer dans ta semaine.
+      </p>
+
+      {/* Filtre sport */}
+      <SportTabs
+        tabs={[
+          { id: 'all', label: 'Tous', color: 'var(--primary)' },
+          ...SPORTS.map(s => ({ id: s.id, label: s.label, color: s.color })),
+        ]}
+        value={sport}
+        onChange={(id) => setSport(id as Sport | 'all')}
+      />
+
+      {/* État vide — invitation, en attendant le contenu */}
+      <div style={{
+        marginTop: 28, padding: '56px 24px', borderRadius: 'var(--r-lg, 20px)',
+        background: 'var(--bg-card2)', textAlign: 'center',
+        display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12,
+      }}>
+        <div style={{
+          width: 52, height: 52, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'var(--primary-dim)', color: 'var(--primary)',
+        }}>
+          <Library size={24} />
+        </div>
+        <h3 style={{ fontFamily: FD, fontSize: 17, fontWeight: 600, color: 'var(--text)', margin: 0 }}>
+          Bibliothèque en préparation
+        </h3>
+        <p style={{ fontFamily: FB, fontSize: 13, color: 'var(--text-dim)', margin: 0, maxWidth: 420, lineHeight: 1.5 }}>
+          Des dizaines de séances par sport arrivent ici — running, vélo, muscu, natation, hyrox, aviron, triathlon.
+          {sport !== 'all' && ` Filtre actuel : ${sportLabel(sport as Sport)}.`}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export default function SessionPage() {
   const [templates,     setTemplates]     = useState<SessionTemplate[]>(MOCK_TEMPLATES)
+  const [topTab,        setTopTab]        = useState<TopTab>('builder')
   const [mode,          setMode]          = useState<PageMode>('library')
   const [editTarget,    setEditTarget]    = useState<SessionTemplate|undefined>()
   const [execTarget,    setExecTarget]    = useState<SessionTemplate|undefined>()
@@ -2105,75 +2162,61 @@ export default function SessionPage() {
     }
   }
 
-  const titleMap: Record<PageMode,string> = {
-    library: 'Session', build: editTarget ? 'Modifier la seance' : 'Nouvelle seance', execute: execTarget?.name ?? 'Seance en cours',
-  }
-  const subMap: Record<PageMode,string> = {
-    library: 'Bibliotheque de seances types', build: '', execute: execTarget ? sportLabel(execTarget.sport) : '',
-  }
+  const TABS: PageTab<TopTab>[] = [
+    { id: 'builder', label: 'Builder',      short: 'Builder', subtitle: 'Créer & réutiliser', icon: Dumbbell },
+    { id: 'biblio',  label: 'Bibliothèque', short: 'Biblio',  subtitle: 'Séances expliquées', icon: Library },
+  ]
+
+  const helpBtn = (
+    <button onClick={reopen} aria-label="Aide" style={{
+      width: 28, height: 28, borderRadius: '50%', background: 'var(--primary-dim)',
+      border: 'none', color: 'var(--primary)', fontFamily: FB, fontSize: 13, fontWeight: 700,
+      cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+    }}>?</button>
+  )
 
   return (
-    <div style={{ padding:'24px 28px', maxWidth:'100%' }}>
+    <>
       <PageHelp config={SESSION_ONBOARDING} show={show} onDismiss={dismiss} />
-      <style>{`
-        @media (max-width:767px) {
-          .session-header { flex-direction: column !important; gap: 12px !important; }
-        }
-      `}</style>
+      <TabbedPageLayout headerExtra={helpBtn} tabs={TABS} active={topTab} onChange={setTopTab}>
+        {topTab === 'builder' ? (
+          <>
+            {mode === 'library' && (
+              <LibraryMode
+                templates={templates}
+                onNew={handleNew}
+                onEdit={handleEdit}
+                onStart={handleStart}
+                onDelete={handleDelete}
+              />
+            )}
 
-      {/* Header */}
-      <div className="session-header" style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginBottom:24 }}>
-        <div>
-          <h1 style={{ fontFamily:'Syne,sans-serif', fontSize:24, fontWeight:700, letterSpacing:'-0.03em', margin:0 }}>
-            {titleMap[mode]}
-          </h1>
-          <p style={{ fontSize:12, color:'var(--text-dim)', margin:'5px 0 0' }}>
-            {subMap[mode] || new Date().toLocaleDateString('fr-FR', { weekday:'long', day:'numeric', month:'long', year:'numeric' })}
-          </p>
-        </div>
-        <div style={{ display:'flex', alignItems:'center', gap:8 }}>
-          {mode !== 'library' && (
-            <button onClick={()=>setMode('library')}
-              style={{ padding:'8px 16px', borderRadius:10, border:'1px solid var(--border)', background:'transparent', color:'var(--text-mid)', fontFamily:'DM Sans,sans-serif', fontSize:13, cursor:'pointer' }}>
-              ← Bibliotheque
-            </button>
-          )}
-          <button onClick={reopen} style={{ width:28,height:28,borderRadius:'50%',background:'rgba(6,182,212,0.1)',border:'1px solid rgba(6,182,212,0.25)',color:'#06B6D4',fontSize:13,fontWeight:700,cursor:'pointer',display:'flex',alignItems:'center',justifyContent:'center',flexShrink:0 }}>?</button>
-        </div>
-      </div>
+            {mode === 'build' && (
+              <BuildMode
+                initial={editTarget}
+                onSave={handleSave}
+                onCancel={()=>setMode('library')}
+              />
+            )}
 
-      {mode === 'library' && (
-        <LibraryMode
-          templates={templates}
-          onNew={handleNew}
-          onEdit={handleEdit}
-          onStart={handleStart}
-          onDelete={handleDelete}
-        />
-      )}
-
-      {mode === 'build' && (
-        <BuildMode
-          initial={editTarget}
-          onSave={handleSave}
-          onCancel={()=>setMode('library')}
-        />
-      )}
-
-      {mode === 'execute' && execTarget && (
-        <div>
-          {execTarget.sport === 'muscu' && (
-            <ExecuteMuscu template={execTarget} onExit={()=>setMode('library')}/>
-          )}
-          {(execTarget.sport==='running'||execTarget.sport==='velo'||execTarget.sport==='aviron'||execTarget.sport==='triathlon') && (
-            <ExecuteEndurance template={execTarget} onExit={()=>setMode('library')}/>
-          )}
-          {(execTarget.sport==='natation'||execTarget.sport==='hyrox') && (
-            <ExecuteEndurance template={execTarget} onExit={()=>setMode('library')}/>
-          )}
-        </div>
-      )}
-
-    </div>
+            {mode === 'execute' && execTarget && (
+              <div>
+                {execTarget.sport === 'muscu' && (
+                  <ExecuteMuscu template={execTarget} onExit={()=>setMode('library')}/>
+                )}
+                {(execTarget.sport==='running'||execTarget.sport==='velo'||execTarget.sport==='aviron'||execTarget.sport==='triathlon') && (
+                  <ExecuteEndurance template={execTarget} onExit={()=>setMode('library')}/>
+                )}
+                {(execTarget.sport==='natation'||execTarget.sport==='hyrox') && (
+                  <ExecuteEndurance template={execTarget} onExit={()=>setMode('library')}/>
+                )}
+              </div>
+            )}
+          </>
+        ) : (
+          <BibliothequeTab />
+        )}
+      </TabbedPageLayout>
+    </>
   )
 }

--- a/src/app/session/page.tsx
+++ b/src/app/session/page.tsx
@@ -8,6 +8,7 @@ import { SportTabs } from '@/components/ui/SportTabs'
 import { TabbedPageLayout, type PageTab } from '@/components/ui/TabbedPageLayout'
 import { Dumbbell, Library } from 'lucide-react'
 import { EXERCISE_DATABASE, type ExoCategory } from '@/components/planning/exercises'
+import RouteIntervals, { type RouteData } from '@/components/session/RouteIntervals'
 import { useTrainingZones } from '@/hooks/useTrainingZones'
 import { usePlanning } from '@/hooks/usePlanning'
 import { PageHelp } from '@/onboarding/system/PageHelp'
@@ -76,6 +77,7 @@ interface MusculaireSession {
 }
 interface EnduranceSession {
   blocks: EnduranceBlock[]
+  route?: RouteData   // parcours importé (GPX) + intervalles posés dessus
 }
 interface NatationSession {
   sets: SwimSet[]
@@ -759,7 +761,7 @@ function EnduranceBuilder({
   const dragIdx = useRef<number | null>(null)
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
 
-  function upd(b: EnduranceBlock[]) { onChange({ blocks: b }) }
+  function upd(b: EnduranceBlock[]) { onChange({ ...data, blocks: b }) }
   function addBlock() {
     upd([...blocks, {
       id: uid(), name: 'Bloc',
@@ -803,6 +805,24 @@ function EnduranceBuilder({
 
   return (
     <div>
+      {/* Parcours : upload GPX + intervalles posés sur carte + profil */}
+      <RouteIntervals
+        value={data.route}
+        onChange={r => onChange({ ...data, route: r })}
+        zoneColor={ZONE_COLOR}
+        accent={color}
+        onApply={segments => {
+          const newBlocks: EnduranceBlock[] = segments.map((seg, i) => ({
+            id: uid(), name: `Parcours — Seg ${i + 1}`,
+            reps: 1, intervalType: 'distance' as const,
+            effortMmSs: '0:00', effortDistanceM: Math.round(seg.distanceM),
+            zone: seg.zone as Zone,
+            recoveryMmSs: '0:00', recoveryZone: 1 as Zone,
+          }))
+          onChange({ ...data, blocks: [...blocks, ...newBlocks] })
+        }}
+      />
+
       {/* Athlete zones banner */}
       {zones && (zones.ftp || zones.runThresholdPace || zones.runZ2 || zones.bikeZ4) && (
         <div style={{ padding:'8px 12px', borderRadius:9, background:'rgba(91,111,255,0.07)', border:'1px solid rgba(91,111,255,0.15)', marginBottom:12, fontSize:11, color:'var(--text-mid)', display:'flex', gap:16, flexWrap:'wrap' }}>

--- a/src/components/gpx/ParcoursViewer.tsx
+++ b/src/components/gpx/ParcoursViewer.tsx
@@ -1,0 +1,156 @@
+'use client'
+// ══════════════════════════════════════════════════════════════════
+// ParcoursViewer — visualiseur de parcours réutilisable (Course + Stage).
+// Rendu calqué sur la page Training : carte ActivityMapInner (mêmes tuiles +
+// bascule Std/Sat/Hyb) + profil d'altitude SVG synchronisé (survol du profil
+// → marqueur sur la carte) + KPIs (distance, D+, D−, alt min/max).
+// Source : un fichier GPX local (File, aperçu immédiat) OU une URL stockée.
+// Réutilise le parseur src/lib/gpxParser.ts.
+// ══════════════════════════════════════════════════════════════════
+import { useEffect, useMemo, useState } from 'react'
+import dynamic from 'next/dynamic'
+import { parseGPX } from '@/lib/gpxParser'
+
+const MapInner = dynamic(() => import('@/components/activity/ActivityMapInner'), {
+  ssr: false,
+  loading: () => (
+    <div style={{ width:'100%', height:'100%', display:'flex', alignItems:'center', justifyContent:'center', background:'#0F172A', color:'#64748B', fontSize:12 }}>
+      Chargement de la carte…
+    </div>
+  ),
+})
+
+interface Parsed {
+  points: { lat: number; lng: number }[]
+  elev: { distanceM: number; altitudeM: number }[]
+  distanceM: number
+  gain: number
+  loss: number
+  altMin: number
+  altMax: number
+}
+
+function analyse(gpxText: string): Parsed | null {
+  const p = parseGPX(gpxText)
+  if (p.waypoints.length < 2) return null
+  let loss = 0
+  for (let i = 1; i < p.elevationProfile.length; i++) {
+    const d = p.elevationProfile[i].altitudeM - p.elevationProfile[i - 1].altitudeM
+    if (d < 0) loss -= d
+  }
+  const alts = p.elevationProfile.map(e => e.altitudeM)
+  return {
+    points: p.waypoints.map(w => ({ lat: w.lat, lng: w.lng })),
+    elev: p.elevationProfile,
+    distanceM: p.distanceM,
+    gain: p.elevGain,
+    loss: Math.round(loss),
+    altMin: alts.length ? Math.min(...alts) : 0,
+    altMax: alts.length ? Math.max(...alts) : 0,
+  }
+}
+
+export default function ParcoursViewer({ file, fileUrl, mapHeight = 230 }: {
+  file?: File
+  fileUrl?: string
+  mapHeight?: number
+}) {
+  const [data, setData] = useState<Parsed | null>(null)
+  const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading')
+  const [layer, setLayer] = useState<'std' | 'sat' | 'hyb'>('std')
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus('loading'); setData(null)
+    ;(async () => {
+      try {
+        const text = file ? await file.text() : fileUrl ? await fetch(fileUrl).then(r => r.text()) : null
+        if (!text) { if (!cancelled) setStatus('error'); return }
+        const parsed = analyse(text)
+        if (cancelled) return
+        if (!parsed) { setStatus('error'); return }
+        setData(parsed); setStatus('ok')
+      } catch { if (!cancelled) setStatus('error') }
+    })()
+    return () => { cancelled = true }
+  }, [file, fileUrl])
+
+  // ── Profil SVG ──
+  const W = 500, H = 120, PL = 34, PR = 8, PT = 10, PB = 18
+  const cW = W - PL - PR, cH = H - PT - PB
+  const prof = data?.elev ?? []
+  const totD = data?.distanceM || 1
+  const eMin = data?.altMin ?? 0, eMax = data?.altMax ?? 100
+  const eR = eMax - eMin || 1
+  const px = (d: number) => PL + (d / totD) * cW
+  const py = (e: number) => PT + cH - ((e - eMin) / eR) * cH
+  const linePts = useMemo(() => prof.map(p => `${px(p.distanceM)},${py(p.altitudeM)}`).join(' '), [prof])  // eslint-disable-line react-hooks/exhaustive-deps
+  const areaPts = prof.length ? `${px(0)},${py(eMin)} ${linePts} ${px(totD)},${py(eMin)}` : ''
+  const hp = hoverIdx !== null ? prof[hoverIdx] : null
+  const hoverGps = hoverIdx !== null && data ? data.points[hoverIdx] ?? null : null
+
+  function onMove(e: React.MouseEvent<SVGSVGElement>) {
+    if (!prof.length) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    const svgX = ((e.clientX - rect.left) / rect.width) * W
+    const dist = Math.max(0, Math.min(totD, ((svgX - PL) / cW) * totD))
+    let best = 0, bd = Infinity
+    prof.forEach((p, i) => { const d = Math.abs(p.distanceM - dist); if (d < bd) { bd = d; best = i } })
+    setHoverIdx(best)
+  }
+
+  if (status === 'error') {
+    return <p style={{ fontSize:12, color:'#ef4444', margin:'8px 0 0' }}>Parcours illisible — fichier GPX invalide.</p>
+  }
+  if (status === 'loading' || !data) {
+    return <div style={{ height: mapHeight, borderRadius:12, background:'#0F172A', display:'flex', alignItems:'center', justifyContent:'center', color:'#64748B', fontSize:12 }}>Lecture du parcours…</div>
+  }
+
+  const KPI = ({ label, value }: { label: string; value: string }) => (
+    <div style={{ flex:1, minWidth:70 }}>
+      <p style={{ fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.06em', color:'var(--text-dim)', margin:0 }}>{label}</p>
+      <p style={{ fontSize:17, fontWeight:600, color:'var(--text)', margin:'2px 0 0', fontVariantNumeric:'tabular-nums' }}>{value}</p>
+    </div>
+  )
+
+  return (
+    <div style={{ borderRadius:12, overflow:'hidden', border:'1px solid var(--border)' }}>
+      {/* KPIs */}
+      <div style={{ display:'flex', gap:14, padding:'12px 14px', background:'var(--bg-card2)', flexWrap:'wrap' }}>
+        <KPI label="Distance" value={`${(data.distanceM/1000).toFixed(1)} km`} />
+        <KPI label="D+" value={`${Math.round(data.gain)} m`} />
+        <KPI label="D−" value={`${data.loss} m`} />
+        <KPI label="Alt." value={`${Math.round(data.altMin)}–${Math.round(data.altMax)} m`} />
+      </div>
+
+      {/* Carte (façon Training) */}
+      <div style={{ position:'relative', width:'100%', height:mapHeight, background:'#0F172A' }}>
+        <MapInner points={data.points} layer={layer} onLayerChange={setLayer} hoverGps={hoverGps} />
+      </div>
+
+      {/* Profil d'altitude synchronisé */}
+      <div style={{ background:'#111827', borderTop:'1px solid var(--border)' }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none"
+          onMouseMove={onMove} onMouseLeave={() => setHoverIdx(null)}
+          style={{ display:'block', cursor:'crosshair' }}>
+          <polygon points={areaPts} fill="rgba(6,182,212,0.12)" />
+          <polyline points={linePts} fill="none" stroke="#06B6D4" strokeWidth="1.5" />
+          {hp && (
+            <>
+              <line x1={px(hp.distanceM)} y1={PT} x2={px(hp.distanceM)} y2={PT+cH} stroke="rgba(255,255,255,0.35)" strokeWidth="1" strokeDasharray="3,3" />
+              <circle cx={px(hp.distanceM)} cy={py(hp.altitudeM)} r="3.5" fill="#06B6D4" stroke="#fff" strokeWidth="1.5" />
+              <rect x={Math.min(px(hp.distanceM)+5, W-72)} y={Math.max(py(hp.altitudeM)-18, PT)} width={68} height={14} rx={3} fill="rgba(0,0,0,0.8)" />
+              <text x={Math.min(px(hp.distanceM)+8, W-69)} y={Math.max(py(hp.altitudeM)-7, PT+10)} fontSize="8" fill="#e5e7eb">
+                {(hp.distanceM/1000).toFixed(1)}km · {Math.round(hp.altitudeM)}m
+              </text>
+            </>
+          )}
+          <text x={PL-2} y={PT+8}  fontSize="8" fill="#6b7280" textAnchor="end">{Math.round(eMax)}m</text>
+          <text x={PL-2} y={PT+cH} fontSize="8" fill="#6b7280" textAnchor="end">{Math.round(eMin)}m</text>
+          <text x={W-PR}  y={H-4}   fontSize="8" fill="#6b7280" textAnchor="end">{(totD/1000).toFixed(1)}km</text>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/src/components/session/RouteIntervals.tsx
+++ b/src/components/session/RouteIntervals.tsx
@@ -1,0 +1,288 @@
+'use client'
+// ══════════════════════════════════════════════════════════════════
+// RouteIntervals — uploader un parcours (GPX/FIT*) et poser les intervalles
+// DESSUS : carte du tracé + profil d'altitude SYNCHRONISÉS. On découpe le
+// parcours en segments (coupures le long de la distance) ; chaque segment
+// porte une zone d'intensité, affichée à la fois sur le profil (bande
+// colorée) et sur la carte (portion de tracé colorée). Sélection synchro.
+//
+// Réutilise le parseur GPX existant (src/lib/gpxParser.ts) + Leaflet (déjà
+// utilisé par les composants gpx/). *FIT non parsé ici → GPX/TCX/KML XML.
+// ══════════════════════════════════════════════════════════════════
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { parseGPX } from '@/lib/gpxParser'
+
+export interface RoutePoint { lat: number; lon: number }
+export interface RouteElev  { distanceM: number; altitudeM: number }
+export interface RouteData {
+  fileName: string
+  distanceM: number
+  elevGain: number
+  waypoints: RoutePoint[]
+  elevation: RouteElev[]
+  splits: number[]   // coupures en fraction de distance (0..1), triées
+  zones: number[]    // zone par segment (1..5), longueur = splits.length + 1
+}
+export interface RouteSegment { index: number; distanceM: number; zone: number; startFrac: number; endFrac: number }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LeafletMap = any
+
+function downsample<T>(arr: T[], max = 400): { items: T[]; step: number } {
+  if (arr.length <= max) return { items: arr, step: 1 }
+  const step = Math.ceil(arr.length / max)
+  return { items: arr.filter((_, i) => i % step === 0), step }
+}
+
+export function segmentsOf(r: RouteData): RouteSegment[] {
+  const bounds = [0, ...[...r.splits].sort((a, b) => a - b), 1]
+  const segs: RouteSegment[] = []
+  for (let i = 0; i < bounds.length - 1; i++) {
+    segs.push({
+      index: i,
+      startFrac: bounds[i],
+      endFrac: bounds[i + 1],
+      distanceM: Math.max(0, (bounds[i + 1] - bounds[i]) * r.distanceM),
+      zone: r.zones[i] ?? 2,
+    })
+  }
+  return segs
+}
+
+export default function RouteIntervals({
+  value, onChange, zoneColor, accent, onApply,
+}: {
+  value?: RouteData
+  onChange: (v: RouteData | undefined) => void
+  zoneColor: Record<number, string>
+  accent: string
+  onApply: (segments: RouteSegment[]) => void
+}) {
+  const [status, setStatus] = useState<'idle' | 'parsing' | 'error'>('idle')
+  const [selected, setSelected] = useState<number | null>(null)
+  const mapDivRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<LeafletMap | null>(null)
+  const layerRef = useRef<LeafletMap | null>(null)   // LayerGroup des segments
+
+  const segs = value ? segmentsOf(value) : []
+
+  // ── Upload + parse ──
+  async function onFile(file: File) {
+    setStatus('parsing')
+    try {
+      const text = await file.text()
+      const parsed = parseGPX(text)
+      if (parsed.waypoints.length < 2) { setStatus('error'); return }
+      const wp = downsample(parsed.waypoints, 400)
+      const el = downsample(parsed.elevationProfile, 400)
+      onChange({
+        fileName: file.name,
+        distanceM: parsed.distanceM,
+        elevGain: parsed.elevGain,
+        waypoints: wp.items.map(p => ({ lat: p.lat, lon: p.lng })),
+        elevation: el.items.map(p => ({ distanceM: p.distanceM, altitudeM: p.altitudeM })),
+        splits: [],
+        zones: [2],
+      })
+      setSelected(null)
+      setStatus('idle')
+    } catch { setStatus('error') }
+  }
+
+  // ── Carte Leaflet : init quand un nouveau parcours est chargé ──
+  const wpKey = value ? `${value.fileName}:${value.waypoints.length}` : ''
+  useEffect(() => {
+    if (!value || !mapDivRef.current) return
+    let cancelled = false
+    ;(async () => {
+      const L = (await import('leaflet')).default
+      if (cancelled || !mapDivRef.current) return
+      if (!document.getElementById('leaflet-css-gpx')) {
+        const lk = document.createElement('link')
+        lk.id = 'leaflet-css-gpx'; lk.rel = 'stylesheet'
+        lk.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
+        document.head.appendChild(lk)
+      }
+      try { mapRef.current?.remove() } catch { /* ignore */ }
+      const m = L.map(mapDivRef.current, { zoomControl: false, attributionControl: false, scrollWheelZoom: false })
+      mapRef.current = m
+      L.tileLayer(`https://api.mapbox.com/styles/v1/mapbox/outdoors-v12/tiles/512/{z}/{x}/{y}@2x?access_token=${process.env.NEXT_PUBLIC_MAPBOX ?? ''}`,
+        { tileSize: 512, zoomOffset: -1, maxZoom: 20 }).addTo(m)
+      const latlngs = value.waypoints.map(p => [p.lat, p.lon] as [number, number])
+      const bounds = L.latLngBounds(latlngs)
+      m.fitBounds(bounds, { padding: [12, 12] })
+      layerRef.current = L.layerGroup().addTo(m)
+    })()
+    return () => { cancelled = true; try { mapRef.current?.remove() } catch { /* ignore */ } mapRef.current = null }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wpKey])
+
+  // ── Redessine les segments colorés sur la carte (splits/zones/selection) ──
+  const redraw = useCallback(async () => {
+    if (!value || !mapRef.current || !layerRef.current) return
+    const L = (await import('leaflet')).default
+    layerRef.current.clearLayers()
+    const idxOf = (frac: number) => {
+      const target = frac * value.distanceM
+      let best = 0, bd = Infinity
+      value.elevation.forEach((e, i) => { const d = Math.abs(e.distanceM - target); if (d < bd) { bd = d; best = i } })
+      return best
+    }
+    segmentsOf(value).forEach(seg => {
+      const a = idxOf(seg.startFrac), b = Math.max(a + 1, idxOf(seg.endFrac))
+      const pts = value.waypoints.slice(a, b + 1).map(p => [p.lat, p.lon] as [number, number])
+      if (pts.length < 2) return
+      L.polyline(pts, {
+        color: zoneColor[seg.zone] ?? accent,
+        weight: selected === seg.index ? 7 : 4,
+        opacity: selected === null || selected === seg.index ? 1 : 0.45,
+      }).addTo(layerRef.current)
+    })
+  }, [value, selected, zoneColor, accent])
+
+  useEffect(() => { void redraw() }, [redraw])
+
+  // ── Profil SVG ──
+  const W = 500, H = 96, PL = 30, PR = 8, PT = 8, PB = 16
+  const cW = W - PL - PR, cH = H - PT - PB
+  const prof = value?.elevation ?? []
+  const totD = value?.distanceM || 1
+  const minE = prof.length ? Math.min(...prof.map(p => p.altitudeM)) : 0
+  const maxE = prof.length ? Math.max(...prof.map(p => p.altitudeM)) : 100
+  const eR = maxE - minE || 1
+  const px = (d: number) => PL + (d / totD) * cW
+  const py = (e: number) => PT + cH - ((e - minE) / eR) * cH
+  const linePts = prof.map(p => `${px(p.distanceM)},${py(p.altitudeM)}`).join(' ')
+  const areaPts = prof.length ? `${px(0)},${py(minE)} ${linePts} ${px(totD)},${py(minE)}` : ''
+
+  function addSplitAt(clientX: number, rect: DOMRect) {
+    if (!value) return
+    const frac = Math.max(0.02, Math.min(0.98, ((clientX - rect.left) / rect.width)))
+    // refuse une coupure trop proche d'une existante
+    if (value.splits.some(s => Math.abs(s - frac) < 0.02)) return
+    const splits = [...value.splits, frac].sort((a, b) => a - b)
+    // insère la zone du nouveau segment = copie du segment coupé
+    const bounds = [0, ...value.splits.sort((a, b) => a - b), 1]
+    let segIdx = bounds.findIndex((b, i) => i < bounds.length - 1 && frac > b && frac < bounds[i + 1])
+    if (segIdx < 0) segIdx = 0
+    const zones = [...value.zones]
+    zones.splice(segIdx + 1, 0, value.zones[segIdx] ?? 2)
+    onChange({ ...value, splits, zones })
+  }
+
+  function cycleZone(i: number) {
+    if (!value) return
+    const zones = [...value.zones]
+    zones[i] = (zones[i] % 5) + 1
+    onChange({ ...value, zones })
+  }
+  function removeSplitBefore(i: number) {
+    if (!value || i === 0) return
+    const sorted = [...value.splits].sort((a, b) => a - b)
+    sorted.splice(i - 1, 1)
+    const zones = [...value.zones]
+    zones.splice(i, 1)   // fusionne le segment i avec i-1 (garde la zone de i-1)
+    onChange({ ...value, splits: sorted, zones })
+    setSelected(null)
+  }
+
+  const lbl: React.CSSProperties = { fontSize:10, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.08em', color:'var(--text-dim)', margin:0 }
+
+  // ── État vide : zone d'upload ──
+  if (!value) {
+    return (
+      <div style={{ marginBottom:16, padding:'18px 16px', borderRadius:14, border:'1px dashed var(--border)', background:'var(--bg-card2)' }}>
+        <p style={{ ...lbl, marginBottom:8 }}>Parcours</p>
+        <label style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'9px 16px', borderRadius:10, border:`1px solid ${accent}`, color:accent, background:`${accent}10`, fontFamily:'DM Sans,sans-serif', fontSize:13, fontWeight:600, cursor:'pointer' }}>
+          {status === 'parsing' ? 'Lecture…' : 'Importer un parcours (GPX)'}
+          <input type="file" accept=".gpx,.tcx,.kml" style={{ display:'none' }}
+            onChange={e => { const f = e.target.files?.[0]; if (f) void onFile(f) }}/>
+        </label>
+        <p style={{ fontSize:11, color:'var(--text-dim)', margin:'8px 0 0', lineHeight:1.5 }}>
+          Pose ensuite tes intervalles directement sur le tracé et le profil d'altitude.
+        </p>
+        {status === 'error' && <p style={{ fontSize:11, color:'#ef4444', margin:'6px 0 0' }}>Fichier illisible — vérifie que c'est un GPX valide.</p>}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ marginBottom:16, borderRadius:14, border:'1px solid var(--border)', overflow:'hidden', background:'var(--bg-card2)' }}>
+      {/* En-tête */}
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:8, padding:'10px 14px', flexWrap:'wrap' }}>
+        <div>
+          <p style={lbl}>Parcours</p>
+          <p style={{ fontSize:12, color:'var(--text-main)', margin:'2px 0 0', fontFamily:'DM Sans,sans-serif' }}>
+            {value.fileName} · <span style={{ fontFamily:'DM Mono,monospace' }}>{(value.distanceM/1000).toFixed(1)}km · D+{Math.round(value.elevGain)}m</span>
+          </p>
+        </div>
+        <button onClick={() => { onChange(undefined); setSelected(null) }}
+          style={{ background:'none', border:'1px solid var(--border)', borderRadius:8, padding:'5px 10px', cursor:'pointer', color:'var(--text-dim)', fontSize:11, fontFamily:'DM Sans,sans-serif' }}>
+          Retirer
+        </button>
+      </div>
+
+      {/* Carte */}
+      <div ref={mapDivRef} style={{ width:'100%', height:180, background:'#1a1a2e' }} />
+
+      {/* Profil d'altitude + bandes de zones */}
+      <div style={{ background:'#111827', borderTop:'1px solid var(--border)' }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none"
+          style={{ display:'block', cursor:'copy' }}
+          onClick={e => addSplitAt(e.clientX, e.currentTarget.getBoundingClientRect())}>
+          {/* bandes de zones par segment */}
+          {segs.map(seg => (
+            <rect key={`band-${seg.index}`} x={px(seg.startFrac*totD)} y={PT}
+              width={Math.max(0, px(seg.endFrac*totD) - px(seg.startFrac*totD))} height={cH}
+              fill={zoneColor[seg.zone] ?? accent}
+              opacity={selected === null ? 0.16 : selected === seg.index ? 0.32 : 0.07}/>
+          ))}
+          <polygon points={areaPts} fill="rgba(255,255,255,0.06)"/>
+          <polyline points={linePts} fill="none" stroke="#9ca3af" strokeWidth="1.4"/>
+          {/* coupures */}
+          {[...value.splits].sort((a,b)=>a-b).map((s,i) => (
+            <line key={`sp-${i}`} x1={px(s*totD)} y1={PT} x2={px(s*totD)} y2={PT+cH}
+              stroke="#fff" strokeWidth="1.4" strokeDasharray="3,3" opacity={0.7}/>
+          ))}
+          <text x={PL-2} y={PT+8}  fontSize="8" fill="#6b7280" textAnchor="end">{Math.round(maxE)}m</text>
+          <text x={PL-2} y={PT+cH} fontSize="8" fill="#6b7280" textAnchor="end">{Math.round(minE)}m</text>
+          <text x={W-PR}  y={H-3}   fontSize="8" fill="#6b7280" textAnchor="end">{(totD/1000).toFixed(1)}km</text>
+        </svg>
+        <p style={{ fontSize:10, color:'#6b7280', margin:0, padding:'4px 10px 8px' }}>Clique sur le profil pour ajouter une coupure d'intervalle.</p>
+      </div>
+
+      {/* Segments → zone par segment (synchro carte/profil au survol) */}
+      <div style={{ padding:'10px 14px', display:'flex', flexDirection:'column', gap:8 }}>
+        <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
+          {segs.map(seg => {
+            const c = zoneColor[seg.zone] ?? accent
+            const on = selected === seg.index
+            return (
+              <div key={seg.index}
+                onMouseEnter={() => setSelected(seg.index)} onMouseLeave={() => setSelected(null)}
+                style={{ display:'flex', alignItems:'center', gap:6, padding:'5px 8px 5px 10px', borderRadius:99,
+                  border:`1px solid ${on ? c : 'var(--border)'}`, background: on ? `${c}18` : 'var(--bg-card)',
+                  borderLeft:`3px solid ${c}` }}>
+                <span style={{ fontSize:10, color:'var(--text-dim)', fontFamily:'DM Mono,monospace' }}>{seg.index+1}</span>
+                <span style={{ fontSize:11, color:'var(--text-main)', fontFamily:'DM Mono,monospace' }}>{(seg.distanceM/1000).toFixed(2)}km</span>
+                <button onClick={() => cycleZone(seg.index)} title="Changer la zone"
+                  style={{ border:'none', background:'transparent', cursor:'pointer', fontSize:11, fontWeight:700, color:c, fontFamily:'DM Mono,monospace', padding:'0 2px' }}>
+                  Z{seg.zone}
+                </button>
+                {seg.index > 0 && (
+                  <button onClick={() => removeSplitBefore(seg.index)} title="Fusionner avec le précédent"
+                    style={{ border:'none', background:'transparent', cursor:'pointer', fontSize:13, color:'var(--text-dim)', padding:0, lineHeight:1 }}>×</button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        <button onClick={() => onApply(segs)}
+          style={{ alignSelf:'flex-start', padding:'8px 14px', borderRadius:10, border:'none', background:accent, color:'#fff',
+            fontFamily:'DM Sans,sans-serif', fontSize:12, fontWeight:600, cursor:'pointer' }}>
+          Convertir en blocs d'intervalles
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/GlobalSaveToast.tsx
+++ b/src/components/ui/GlobalSaveToast.tsx
@@ -1,0 +1,99 @@
+'use client'
+// ──────────────────────────────────────────────────────────────────────────
+// Animation « Enregistré » globale (pastille top-right + coche dessinée).
+// Monté une seule fois dans ClientShell. Écoute le bus `thw:save`.
+//
+// Garde anti-bruit : n'affiche que les sauvegardes consécutives à une
+// interaction utilisateur récente (clic / saisie / toucher) → les écritures
+// d'arrière-plan au montage ne déclenchent pas l'animation.
+// Plusieurs sauvegardes rapprochées sont fusionnées en une seule pastille.
+// ──────────────────────────────────────────────────────────────────────────
+import { useEffect, useRef, useState } from 'react'
+import { SAVE_EVENT, type SaveEventDetail } from '@/lib/ui/saveToast'
+
+const INTERACTION_WINDOW_MS = 8000
+
+interface ToastState { status: 'saved' | 'error'; message: string; key: number }
+
+export default function GlobalSaveToast() {
+  const [state, setState] = useState<ToastState | null>(null)
+  const [leaving, setLeaving] = useState(false)
+  const lastInteraction = useRef(0)
+  const hideT = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const killT = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    const touch = () => { lastInteraction.current = Date.now() }
+    const events: (keyof WindowEventMap)[] = ['pointerdown', 'keydown', 'touchstart', 'change']
+    events.forEach(ev => window.addEventListener(ev, touch, { passive: true, capture: true }))
+
+    function onSave(e: Event) {
+      // Ignore les écritures non déclenchées par l'utilisateur (background/au montage).
+      if (Date.now() - lastInteraction.current > INTERACTION_WINDOW_MS) return
+      const d = (e as CustomEvent<SaveEventDetail>).detail
+      const message = d.message ?? (d.status === 'error' ? 'Échec de l’enregistrement' : 'Enregistré')
+      setLeaving(false)
+      setState(s => ({ status: d.status, message, key: (s?.key ?? 0) + 1 }))
+      clearTimeout(hideT.current); clearTimeout(killT.current)
+      hideT.current = setTimeout(() => setLeaving(true), 1900)
+      killT.current = setTimeout(() => { setState(null); setLeaving(false) }, 2200)
+    }
+    window.addEventListener(SAVE_EVENT, onSave as EventListener)
+    return () => {
+      events.forEach(ev => window.removeEventListener(ev, touch, { capture: true } as EventListenerOptions))
+      window.removeEventListener(SAVE_EVENT, onSave as EventListener)
+      clearTimeout(hideT.current); clearTimeout(killT.current)
+    }
+  }, [])
+
+  if (!state) return null
+  const err = state.status === 'error'
+  const accent = err ? '#ef4444' : '#10B981'
+
+  return (
+    <>
+      <style>{`
+        @keyframes thwSaveIn { from { opacity:0; transform: translateY(-10px) scale(.92) } to { opacity:1; transform:none } }
+        @keyframes thwSaveOut { from { opacity:1 } to { opacity:0; transform: translateY(-6px) scale(.97) } }
+        @keyframes thwCheckDraw { from { stroke-dashoffset:18 } to { stroke-dashoffset:0 } }
+        @keyframes thwBadgePop { 0%{transform:scale(.4)} 60%{transform:scale(1.12)} 100%{transform:scale(1)} }
+        @keyframes thwBadgePulse { 0%{box-shadow:0 0 0 0 ${accent}55} 70%{box-shadow:0 0 0 8px ${accent}00} 100%{box-shadow:0 0 0 0 ${accent}00} }
+      `}</style>
+      <div
+        key={state.key}
+        role="status"
+        aria-live="polite"
+        style={{
+          position: 'fixed', top: 'calc(16px + env(safe-area-inset-top))', right: 16, zIndex: 10060,
+          display: 'flex', alignItems: 'center', gap: 9,
+          background: err ? 'rgba(239,68,68,0.16)' : 'rgba(16,185,129,0.16)',
+          border: `1px solid ${accent}66`,
+          color: 'var(--text)', borderRadius: 999, padding: '8px 15px 8px 9px',
+          fontSize: 13, fontWeight: 700, letterSpacing: '-0.01em',
+          fontFamily: 'var(--font-body, "DM Sans", sans-serif)',
+          backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+          boxShadow: '0 10px 30px rgba(0,0,0,0.22)',
+          animation: leaving ? 'thwSaveOut .3s ease forwards' : 'thwSaveIn .34s cubic-bezier(.2,.9,.3,1.25)',
+        }}
+      >
+        <span style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          width: 22, height: 22, borderRadius: '50%', background: accent, flexShrink: 0,
+          animation: 'thwBadgePop .42s cubic-bezier(.2,.9,.3,1.4), thwBadgePulse 1.1s ease 1',
+        }}>
+          {err ? (
+            <svg width="11" height="11" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" />
+            </svg>
+          ) : (
+            <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <path d="M2.5 7.4l3 3 6-6.6" stroke="#fff" strokeWidth="2.3" strokeLinecap="round" strokeLinejoin="round"
+                style={{ strokeDasharray: 18, animation: 'thwCheckDraw .42s ease .1s both' }} />
+            </svg>
+          )}
+        </span>
+        {state.message}
+      </div>
+    </>
+  )
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,58 @@
 import { createBrowserClient } from '@supabase/ssr'
+import { emitSaved, emitSaveError } from '@/lib/ui/saveToast'
+
+// Méthodes qui MODIFIENT des données → déclenchent l'animation « Enregistré ».
+// (les lectures `select` ne sont pas instrumentées.)
+const MUTATIONS = new Set(['insert', 'update', 'upsert', 'delete'])
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Enveloppe le builder de requête issu d'une mutation pour émettre un événement
+// `thw:save` à la résolution. Les méthodes de filtre (eq, select, single…)
+// renvoient le même builder → on ré-enveloppe via le proxy pour conserver le
+// hook jusqu'au `await` final.
+function wrapMutationBuilder(builder: any): any {
+  return new Proxy(builder, {
+    get(target, prop, receiver) {
+      if (prop === 'then') {
+        return (onFulfilled?: (v: any) => any, onRejected?: (e: any) => any) =>
+          target.then((res: any) => {
+            if (res && res.error) emitSaveError()
+            else emitSaved()
+            return onFulfilled ? onFulfilled(res) : res
+          }, onRejected)
+      }
+      const val = Reflect.get(target, prop, target)
+      if (typeof val === 'function') {
+        return (...args: any[]) => {
+          const out = val.apply(target, args)
+          // Les builders Supabase renvoient `this` → re-proxifier.
+          return out === target ? receiver : out
+        }
+      }
+      return val
+    },
+  })
+}
 
 export function createClient() {
-  return createBrowserClient(
+  const client = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
   )
+
+  const originalFrom = client.from.bind(client)
+  client.from = ((table: string) => {
+    const qb = originalFrom(table as any)
+    return new Proxy(qb, {
+      get(target, prop, receiver) {
+        const val = Reflect.get(target, prop, target)
+        if (typeof val === 'function' && MUTATIONS.has(prop as string)) {
+          return (...args: any[]) => wrapMutationBuilder((val as any).apply(target, args))
+        }
+        return typeof val === 'function' ? (val as any).bind(target) : val
+      },
+    }) as any
+  }) as typeof client.from
+
+  return client
 }

--- a/src/lib/ui/saveToast.ts
+++ b/src/lib/ui/saveToast.ts
@@ -1,0 +1,25 @@
+// ──────────────────────────────────────────────────────────────────────────
+// Bus d'événements « sauvegarde » global.
+// N'importe quel code peut signaler une sauvegarde réussie / échouée, et le
+// composant <GlobalSaveToast/> (monté une seule fois à la racine) affiche
+// l'animation « Enregistré ». Le client Supabase navigateur émet
+// automatiquement sur chaque mutation (insert/update/upsert/delete), donc
+// toute modification de donnée déclenche l'animation sans câblage manuel.
+// ──────────────────────────────────────────────────────────────────────────
+export type SaveStatus = 'saved' | 'error'
+export const SAVE_EVENT = 'thw:save'
+
+export interface SaveEventDetail {
+  status: SaveStatus
+  message?: string
+}
+
+export function emitSave(status: SaveStatus, message?: string): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent<SaveEventDetail>(SAVE_EVENT, { detail: { status, message } }))
+}
+
+/** Sauvegarde réussie → pastille verte animée. */
+export const emitSaved = (message?: string): void => emitSave('saved', message)
+/** Échec de sauvegarde → pastille rouge. */
+export const emitSaveError = (message?: string): void => emitSave('error', message)


### PR DESCRIPTION
## Planning — builder de séance
- Exos préenregistrés triés, 4 nages, suppression, réordonnancement des blocs, assistance IA
- Import de parcours GPX + intervalles affichés sur carte & profil

## Calendar
- Entrée objectif par clic sur un jour (choix Course / Stage)
- **Course** : upload de parcours avec carte + profil d'altitude (façon Training) + suppression
- **Stage** : refonte complète
  - Sports multi-sélection (sans triathlon, avec muscu)
  - Durée auto via dates début/fin
  - Programme par jour : séances structurées Matin / Après-midi (sport + détail + heure)
  - Plusieurs parcours libres (GPX) avec carte + profil
  - Suppression + confirmation
  - Push auto des séances dans le Planning à la création
  - Persistance dans le JSONB `daily_program` (rétrocompatible, zéro migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCYiE5gX8CK9LUniFfkrLb)_