### PR TITLE
Planning : bouton Brick Run (vélo→course) + flèche reliant les bulles

### DIFF
--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic'
 
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, Fragment } from 'react'
 import { createPortal } from 'react-dom'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
@@ -142,6 +142,8 @@ export interface Session {
   parcoursData?: ParcoursData
   parcoursId?: string
   nutritionItems?: NutritionItem[]
+  // Brick (enchaînement vélo→course) : id partagé entre la séance vélo et sa course.
+  brickId?: string
 }
 interface WeekTask {
   id:string; title:string; type:TaskType; dayIndex:number
@@ -715,7 +717,7 @@ function usePlanning(weekStartParam?:string) {
       user_id:user.id, week_start:weekStart, day_index:s.dayIndex,
       sport:s.sport, title:s.title, time:s.time, duration_min:s.durationMin,
       tss:s.tss??null, status:s.status, notes:s.notes??null,
-      rpe:s.rpe??null, blocks:s.blocks??[], validation_data:{},
+      rpe:s.rpe??null, blocks:s.blocks??[], validation_data: s.brickId ? { brickId:s.brickId } : {},
       plan_variant:s.planVariant??'A',
       parcours_data: s.parcoursData ?? null,
       parcours_id:   s.parcoursId   ?? null,
@@ -732,7 +734,7 @@ function usePlanning(weekStartParam?:string) {
       title:upd.title, time:upd.time, duration_min:upd.durationMin,
       notes:upd.notes??null, rpe:upd.rpe??null, blocks:upd.blocks??[],
       tss:upd.tss??null, status:upd.status,
-      validation_data:{ vDuration:upd.vDuration, vDistance:upd.vDistance, vHrAvg:upd.vHrAvg, vSpeed:upd.vSpeed },
+      validation_data:{ vDuration:upd.vDuration, vDistance:upd.vDistance, vHrAvg:upd.vHrAvg, vSpeed:upd.vSpeed, ...(upd.brickId ? { brickId:upd.brickId } : {}) },
       updated_at:new Date().toISOString(),
     }
     if (upd.sport) patch.sport = upd.sport
@@ -2192,6 +2194,30 @@ function DayBubble({ sport, label, session, done, onClick, draggable, onDragStar
   )
 }
 
+// Réordonne les séances pour placer chaque course « brick » juste après sa séance vélo,
+// et signale les paires (vélo↔course) à relier par une flèche.
+function orderBrickSessions(sessions: Session[]): { list: Session[]; brickRunIds: Set<string> } {
+  const used = new Set<string>(); const list: Session[] = []; const brickRunIds = new Set<string>()
+  for (const s of sessions) {
+    if (used.has(s.id)) continue
+    list.push(s); used.add(s.id)
+    if (s.brickId && sportKeyFromType(s.sport) === 'bike') {
+      const run = sessions.find(r => !used.has(r.id) && r.brickId === s.brickId && sportKeyFromType(r.sport) === 'run')
+      if (run) { list.push(run); used.add(run.id); brickRunIds.add(run.id) }
+    }
+  }
+  return { list, brickRunIds }
+}
+
+// Flèche reliant la bulle vélo à la bulle course (enchaînement brick).
+function BrickArrow() {
+  return (
+    <div aria-hidden style={{ display:'flex', justifyContent:'center', alignItems:'center', margin:'-3px 0', pointerEvents:'none' }}>
+      <svg width="16" height="13" viewBox="0 0 16 13"><path d="M8 1 V8 M4.5 5 L8 8.5 L11.5 5" stroke="var(--text-mid)" strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" /></svg>
+    </div>
+  )
+}
+
 // Descripteur compact d'un bloc d'endurance (intervalle ou continu).
 function enduranceBlockLine(b: Block): string {
   const parts: string[] = []
@@ -2742,13 +2768,20 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
                       {d.activities.map(a => (
                         <DayBubble key={a.id} sport={normalizeSportType(a.sport)} label={formatHM(Math.round(a.elapsedTime / 60))} done onClick={() => setActivityDetail(a)} />
                       ))}
-                      {d.sessions.filter(s => !d.activities.some(a => matchActivity(a, d.sessions)?.id === s.id)).map(s => (
-                        <DayBubble key={s.id} sport={s.sport} session={s} label={formatHM(s.durationMin)} done={s.status === 'done'}
-                          draggable
-                          onDragStart={e => { planDrag.current = { id: s.id, ws, day: i }; e.dataTransfer.effectAllowed = 'move' }}
-                          onDragEnd={() => { planDrag.current = null; setDragCell(null) }}
-                          onClick={() => setDetailModal(s)} />
-                      ))}
+                      {(() => {
+                        const filtered = d.sessions.filter(s => !d.activities.some(a => matchActivity(a, d.sessions)?.id === s.id))
+                        const { list, brickRunIds } = orderBrickSessions(filtered)
+                        return list.map(s => (
+                          <Fragment key={s.id}>
+                            {brickRunIds.has(s.id) && <BrickArrow />}
+                            <DayBubble sport={s.sport} session={s} label={formatHM(s.durationMin)} done={s.status === 'done'}
+                              draggable
+                              onDragStart={e => { planDrag.current = { id: s.id, ws, day: i }; e.dataTransfer.effectAllowed = 'move' }}
+                              onDragEnd={() => { planDrag.current = null; setDragCell(null) }}
+                              onClick={() => setDetailModal(s)} />
+                          </Fragment>
+                        ))
+                      })()}
                     </div>
                   )
                 })}
@@ -2813,7 +2846,15 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
                               plus onPlus={() => setDayPicker(p => p === `m_${hid}` ? null : `m_${hid}`)} open={dayPicker === `m_${hid}`}
                               onPick={(it) => { void setDayIntensityWeek(ws, i, it); setDayPicker(null) }}
                               onNum={() => { setAddModalFavorites(false); setAddModal({ dayIndex:i, plan:activePlan, weekStart:ws }) }} />
-                            {sess.map(s=><DayBubble key={s.id} sport={s.sport} session={s} label={formatHM(s.durationMin)} done={s.status==='done'} lifted={tDrag?.id===s.id} {...bubbleTouch(s.id, ws)} onClick={()=>{ if(tDragRef.current){ tDragRef.current=false; return } setDetailModal(s) }} />)}
+                            {(() => {
+                              const { list, brickRunIds } = orderBrickSessions(sess)
+                              return list.map(s => (
+                                <Fragment key={s.id}>
+                                  {brickRunIds.has(s.id) && <BrickArrow />}
+                                  <DayBubble sport={s.sport} session={s} label={formatHM(s.durationMin)} done={s.status==='done'} lifted={tDrag?.id===s.id} {...bubbleTouch(s.id, ws)} onClick={()=>{ if(tDragRef.current){ tDragRef.current=false; return } setDetailModal(s) }} />
+                                </Fragment>
+                              ))
+                            })()}
                             {acts.map(a=><DayBubble key={a.id} sport={normalizeSportType(a.sport)} label={formatHM(Math.round(a.elapsedTime/60))} done onClick={()=>setActivityDetail(a)} />)}
                           </div>
                         )
@@ -2927,7 +2968,7 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
         user_id: user.id, week_start: targetWeekStart, day_index: dayIdx,
         sport: s.sport, title: s.title, time: s.time, duration_min: s.durationMin,
         tss: s.tss ?? null, status: s.status, notes: s.notes ?? null,
-        rpe: s.rpe ?? null, blocks: s.blocks ?? [], validation_data: {},
+        rpe: s.rpe ?? null, blocks: s.blocks ?? [], validation_data: s.brickId ? { brickId: s.brickId } : {},
         plan_variant: s.planVariant ?? activePlan,
         parcours_data: s.parcoursData ?? null,
         nutrition_data: typedS.nutritionItems ?? null,
@@ -3221,7 +3262,15 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
                       <p style={{ fontSize:9,fontWeight:700,textTransform:'uppercase' as const,letterSpacing:'0.02em',margin:0,color:today?'var(--text)':'var(--text-dim)' }}>{d.day}</p>
                       <p className="tnum" style={{ fontSize:14,fontWeight:700,margin:0,color:'var(--text)' }}>{wDates[i]}</p>
                     </div>
-                    {sess.map(s=><DayBubble key={s.id} sport={s.sport} label={formatHM(s.durationMin)} done={s.status==='done'} onClick={()=>setDetailModal(s)} />)}
+                    {(() => {
+                      const { list, brickRunIds } = orderBrickSessions(sess)
+                      return list.map(s => (
+                        <Fragment key={s.id}>
+                          {brickRunIds.has(s.id) && <BrickArrow />}
+                          <DayBubble sport={s.sport} session={s} label={formatHM(s.durationMin)} done={s.status==='done'} onClick={()=>setDetailModal(s)} />
+                        </Fragment>
+                      ))
+                    })()}
                     {acts.map(a=><DayBubble key={a.id} sport={normalizeSportType(a.sport)} label={formatHM(Math.round(a.elapsedTime/60))} done onClick={()=>setActivityDetail(a)} />)}
                   </div>
                 )
@@ -3281,6 +3330,7 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
           plan={addModal.plan}
           onClose={()=>{setAddModal(null);setAddModalFavorites(false)}}
           onSave={(s)=>{ handleAddSession(addModal.dayIndex, s, addModal.weekStart); setAddModal(null); setAddModalFavorites(false) }}
+          onCreateBrick={(run)=>handleAddSession(addModal.dayIndex, run, addModal.weekStart)}
           openWithFavorites={addModalFavorites}
         />
       )}
@@ -3294,6 +3344,7 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
           onValidate={handleValidate}
           onAutoSave={handleAutoSaveSession}
           onDuplicate={(dayIdx, s) => { addSession({ ...s, dayIndex: dayIdx, planVariant: s.planVariant ?? activePlan }); setDetailModal(null) }}
+          onCreateBrick={(run)=>handleAddSession(run.dayIndex, run)}
         />
       )}
       {activityDetail && <ActivityQuickModal activity={activityDetail} onClose={()=>setActivityDetail(null)}/>}

--- a/src/components/planning/SessionEditor.tsx
+++ b/src/components/planning/SessionEditor.tsx
@@ -3487,7 +3487,14 @@ function SessionExecute({ blocks, sport, sessionTitle, onExit, onSaveLog, exoHis
 
 // ──────────────────────────────────────────────────────────────
 
-export function SessionEditor({ mode, session, dayIndex, plan, onClose, onSave, onDelete, onValidate, onAutoSave, onDuplicate, openWithFavorites }: {
+// Ajoute des minutes à une heure "HH:MM" (clamp à 23:59).
+function addMinutesToTime(hhmm: string, addMin: number): string {
+  const [h, m] = (hhmm || '09:00').split(':').map(n => parseInt(n, 10) || 0)
+  const total = Math.min(h * 60 + m + Math.round(addMin), 23 * 60 + 59)
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`
+}
+
+export function SessionEditor({ mode, session, dayIndex, plan, onClose, onSave, onDelete, onValidate, onAutoSave, onDuplicate, onCreateBrick, openWithFavorites }: {
   mode: 'create' | 'edit'
   session?: Session
   dayIndex?: number
@@ -3498,11 +3505,13 @@ export function SessionEditor({ mode, session, dayIndex, plan, onClose, onSave, 
   onValidate?: (s: Session) => void
   onAutoSave?: (s: Session) => void
   onDuplicate?: (dayIndex: number, session: Session) => void
+  onCreateBrick?: (run: Session) => void
   openWithFavorites?: boolean
 }) {
   const isEdit = mode === 'edit'
   const [sport, setSport] = useState<SportType>(session?.sport ?? 'run')
   const [cyclingSub, setCyclingSub] = useState<CyclingSub>('velo')
+  const [brickRun, setBrickRun] = useState<boolean>(!!session?.brickId)
   const [trainingTypes, setTrainingTypes] = useState<string[]>([])
   const [title, setTitle] = useState(session?.title ?? '')
   const [date, setDate] = useState('')
@@ -4119,6 +4128,9 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
       : aiFlowStep === 'parcours' && parcoursData
         ? buildParcoursBlocks()
         : blocks
+    // Brick (vélo→course) : id partagé entre la séance vélo et sa course.
+    const wantBrick = sport === 'bike' && brickRun
+    const brickId = wantBrick ? (session?.brickId ?? `brk_${Date.now()}`) : undefined
     const savedSession: Session = {
       ...(session ?? {}),
       id: session?.id ?? '',
@@ -4130,8 +4142,19 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
       parcoursData: parcoursDataWithConfig() ?? undefined,
       parcoursId: parcoursData?.parcoursId ?? undefined,
       nutritionItems: nutritionItems.length > 0 ? nutritionItems : undefined,
+      brickId,
     }
     onSave(savedSession)
+    // Création auto de la course d'enchaînement (uniquement quand on active le brick).
+    if (wantBrick && !session?.brickId && onCreateBrick) {
+      const runStart = addMinutesToTime(time, finalDur)
+      onCreateBrick({
+        id: '', dayIndex: savedSession.dayIndex, sport: 'run',
+        title: 'Brick run', time: runStart, durationMin: 20,
+        status: 'planned', rpe, planVariant: selPlan, brickId,
+        blocks: [{ id: `b_${Date.now()}`, mode: 'single', type: 'effort', durationMin: 20, zone: 2, value: '', hrAvg: '', label: 'Course à pied' }],
+      })
+    }
     onClose()
   }
 
@@ -4634,7 +4657,7 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
     const panelProps: SessionEditorPanelProps = {
       mode,
       sport, accent: mobileSportColor(sport), onSportChange: handleSportChange,
-      cyclingSub, setCyclingSub, trainingTypes, setTrainingTypes,
+      cyclingSub, setCyclingSub, brickRun, setBrickRun, trainingTypes, setTrainingTypes,
       title, setTitle, date, setDate, time, setTime,
       dur, setDur, rpe, setRpe, desc, setDesc, selPlan,
       blocks, setBlocks,
@@ -4893,7 +4916,7 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
               </div>
 
               {sport === 'bike' && (
-                <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+                <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' as const, alignItems: 'center' }}>
                   {(Object.keys(CYCLING_SUB_LABEL) as CyclingSub[]).map(sub => (
                     <button key={sub} onClick={() => setCyclingSub(sub)} style={{
                       padding: '5px 12px', borderRadius: 7, fontSize: 11, fontWeight: 600, cursor: 'pointer',
@@ -4902,6 +4925,18 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
                       color: cyclingSub === sub ? accent : 'var(--text-dim)',
                     }}>{CYCLING_SUB_LABEL[sub]}</button>
                   ))}
+                  {/* Brick Run : enchaînement vélo→course (crée une course liée). */}
+                  <button onClick={() => setBrickRun(b => !b)} title="Enchaînement vélo → course à pied"
+                    style={{
+                      padding: '5px 12px', borderRadius: 7, fontSize: 11, fontWeight: 700, cursor: 'pointer',
+                      marginLeft: 'auto',
+                      border: `1px solid ${brickRun ? SPORT_BORDER['run'] : 'var(--border)'}`,
+                      background: brickRun ? `${SPORT_BORDER['run']}1f` : 'transparent',
+                      color: brickRun ? SPORT_BORDER['run'] : 'var(--text-dim)',
+                      display: 'flex', alignItems: 'center', gap: 5,
+                    }}>
+                    {brickRun ? '✓ ' : '+ '}Brick Run
+                  </button>
                 </div>
               )}
             </div>

--- a/src/components/planning/mobile/MainFields.tsx
+++ b/src/components/planning/mobile/MainFields.tsx
@@ -18,6 +18,7 @@ const RPE_DESC = ['Très facile', 'Très facile', 'Facile', 'Facile', 'Modéré'
 export function MainFields(p: {
   sport: SportType; accent: string; onSportChange: (s: SportType) => void
   cyclingSub: CyclingSub; setCyclingSub: (s: CyclingSub) => void
+  brickRun: boolean; setBrickRun: (b: boolean) => void
   trainingTypes: string[]; setTrainingTypes: (t: string[]) => void
   date: string; setDate: (v: string) => void; time: string; setTime: (v: string) => void
   dur: number; setDur: (n: number) => void
@@ -66,6 +67,18 @@ export function MainFields(p: {
             return <button key={k} type="button" onClick={() => p.setCyclingSub(k)} style={{ flex: 1, padding: '11px 8px', borderRadius: 'var(--se-r-sm)', cursor: 'pointer', fontSize: 13, fontWeight: 600, border: `1px solid ${on ? p.accent : 'var(--se-rule)'}`, background: 'var(--se-card)', color: on ? p.accent : 'var(--se-dim)' }}>{CYCLING_SUB_LABEL[k]}</button>
           })}
         </div>
+      )}
+
+      {/* Brick Run : enchaînement vélo → course à pied (crée une course liée) */}
+      {p.sport === 'bike' && (
+        <button type="button" onClick={() => p.setBrickRun(!p.brickRun)} title="Enchaînement vélo → course à pied"
+          style={{ alignSelf: 'flex-start', padding: '10px 16px', borderRadius: 999, cursor: 'pointer', fontSize: 13, fontWeight: 700,
+            border: `1px solid ${p.brickRun ? sportColor('run') : 'var(--se-rule)'}`,
+            background: p.brickRun ? `${sportColor('run')}1f` : 'var(--se-card)',
+            color: p.brickRun ? sportColor('run') : 'var(--se-dim)', display: 'flex', alignItems: 'center', gap: 7 }}>
+          {p.brickRun ? '✓' : '+'} Brick Run
+          <span style={{ fontSize: 11, fontWeight: 500, opacity: 0.85 }}>vélo → course</span>
+        </button>
       )}
 
       {/* Type de séance */}

--- a/src/components/planning/mobile/SessionEditorDesktop.tsx
+++ b/src/components/planning/mobile/SessionEditorDesktop.tsx
@@ -37,6 +37,7 @@ export function SessionEditorDesktop(p: SessionEditorPanelProps) {
             <MainFields
               sport={p.sport} accent={p.accent} onSportChange={p.onSportChange}
               cyclingSub={p.cyclingSub} setCyclingSub={p.setCyclingSub}
+              brickRun={p.brickRun} setBrickRun={p.setBrickRun}
               trainingTypes={p.trainingTypes} setTrainingTypes={p.setTrainingTypes}
               date={p.date} setDate={p.setDate} time={p.time} setTime={p.setTime}
               dur={p.dur} setDur={p.setDur} rpe={p.rpe} setRpe={p.setRpe}

--- a/src/components/planning/mobile/SessionEditorMobile.tsx
+++ b/src/components/planning/mobile/SessionEditorMobile.tsx
@@ -35,6 +35,7 @@ export function SessionEditorMobile(p: SessionEditorPanelProps) {
           <MainFields
             sport={p.sport} accent={p.accent} onSportChange={p.onSportChange}
             cyclingSub={p.cyclingSub} setCyclingSub={p.setCyclingSub}
+            brickRun={p.brickRun} setBrickRun={p.setBrickRun}
             trainingTypes={p.trainingTypes} setTrainingTypes={p.setTrainingTypes}
             date={p.date} setDate={p.setDate} time={p.time} setTime={p.setTime}
             dur={p.dur} setDur={p.setDur} rpe={p.rpe} setRpe={p.setRpe}

--- a/src/components/planning/mobile/panelProps.ts
+++ b/src/components/planning/mobile/panelProps.ts
@@ -9,6 +9,7 @@ export interface SessionEditorPanelProps {
   mode: 'create' | 'edit'
   sport: SportType; accent: string; onSportChange: (s: SportType) => void
   cyclingSub: CyclingSub; setCyclingSub: (s: CyclingSub) => void
+  brickRun: boolean; setBrickRun: (b: boolean) => void
   trainingTypes: string[]; setTrainingTypes: (t: string[]) => void
   title: string; setTitle: (v: string) => void
   date: string; setDate: (v: string) => void; time: string; setTime: (v: string) => void


### PR DESCRIPTION
## Brick Run (enchaînement vélo → course)
- **Éditeur de séance vélo** : nouveau bouton **« Brick Run »**. À l'activation, une **course liée** est créée automatiquement le même jour, juste après le vélo (id de brick partagé, persisté dans `validation_data` — zéro migration).
- **Planning** : une **flèche relie la bulle vélo à la bulle course** du brick (la course est réordonnée juste sous le vélo). Appliqué aux vues semaine desktop, multi-semaines mobile et bandeau compact 7 jours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCYiE5gX8CK9LUniFfkrLb)_