### PR TITLE
Fix Planning mobile : bandes noires éditeur, activités réalisées, suppression, bulles

### DIFF
--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -2169,13 +2169,13 @@ function DayBubble({ sport, label, session, done, onClick, draggable, onDragStar
           onTouchStart={onTouchStart} onTouchMove={onTouchMove} onTouchEnd={onTouchEnd}
           onMouseEnter={e => setTip(e.currentTarget.getBoundingClientRect())} onMouseLeave={() => setTip(null)}
           style={{ display:'flex',flexDirection:'column',alignItems:'stretch',gap:2,padding:'4px 6px',borderRadius:8,border:'none',borderLeft:`2px solid ${color}`,background:'var(--bg-card2)',cursor:'pointer',width:'100%',boxSizing:'border-box',opacity:done?0.55:1,transform:lifted?'scale(1.06)':undefined,boxShadow:lifted?'0 6px 16px rgba(0,0,0,0.35)':undefined,transition:'transform .12s, box-shadow .12s',touchAction:onTouchStart?'pan-y':undefined,position:'relative',zIndex:lifted?20:undefined }}>
-          <div style={{ display:'flex',alignItems:'center',gap:4,minWidth:0 }}>
-            {Ico ? <Ico size={13} color={color} stroke={2.2} /> : <span style={{ width:7,height:7,borderRadius:'50%',background:color,flexShrink:0 }} />}
-            <span style={{ flex:1,minWidth:0,fontSize:9.5,fontWeight:700,color:'var(--text)',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap',textAlign:'left' }}>{session.title || (cfg?.label ?? sport)}</span>
+          <div style={{ display:'flex',alignItems:'flex-start',gap:4,minWidth:0 }}>
+            {Ico ? <span style={{ flexShrink:0,marginTop:1,display:'flex' }}><Ico size={13} color={color} stroke={2.2} /></span> : <span style={{ width:7,height:7,borderRadius:'50%',background:color,flexShrink:0,marginTop:3 }} />}
+            <span style={{ flex:1,minWidth:0,fontSize:9.5,fontWeight:700,lineHeight:1.18,color:'var(--text)',textAlign:'left',display:'-webkit-box',WebkitLineClamp:2,WebkitBoxOrient:'vertical',overflow:'hidden',overflowWrap:'anywhere',wordBreak:'break-word' }}>{session.title || (cfg?.label ?? sport)}</span>
           </div>
-          <div style={{ display:'flex',alignItems:'center',justifyContent:'center',gap:5 }}>
-            <span className="tnum" style={{ fontSize:9,fontWeight:700,color }}>{formatHM(session.durationMin)}</span>
-            {session.rpe != null && <span className="tnum" style={{ fontSize:8.5,fontWeight:600,color:'var(--text-dim)' }}>RPE {session.rpe}</span>}
+          <div style={{ display:'flex',alignItems:'center',justifyContent:'center',gap:5,flexWrap:'wrap' }}>
+            <span className="tnum" style={{ fontSize:9,fontWeight:700,color,whiteSpace:'nowrap' }}>{formatHM(session.durationMin)}</span>
+            {session.rpe != null && <span className="tnum" style={{ fontSize:8.5,fontWeight:600,color:'var(--text-dim)',whiteSpace:'nowrap' }}>RPE {session.rpe}</span>}
           </div>
         </button>
         {tip && <SessionTipPortal anchor={tip} session={session} />}
@@ -2839,7 +2839,7 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
                         const hid = `${ws}_${i}`
                         const isDropTarget = !!tDrag && dragCell===hid
                         const sess = d.sessions.filter(s=>!d.activities.some(a=>matchActivity(a,d.sessions)?.id===s.id))
-                        const acts = d.activities.filter(a=>!matchActivity(a,d.sessions))
+                        const acts = d.activities  // toutes les activités réalisées (comme desktop)
                         return (
                           <div key={i} data-mday={i} data-mws={ws} style={{ minWidth:0, display:'flex', flexDirection:'column' as const, gap:3, alignItems:'center', borderRadius:8, background:isDropTarget?'var(--primary-dim)':'transparent', transition:'background .12s' }}>
                             <DayHeader abbr={d.day} num={dates[i]} intensity={d.intensity} isToday={isToday}
@@ -3255,7 +3255,7 @@ function TrainingTab({ tab = 'plan' }: { tab?: 'training' | 'plan' }) {
               {w.map((d,i)=>{
                 const today = i===todayIdx && isCurrentWeek
                 const sess = d.sessions.filter(s=>!d.activities.some(a=>matchActivity(a,d.sessions)?.id===s.id))
-                const acts = d.activities.filter(a=>!matchActivity(a,d.sessions))
+                const acts = d.activities  // toutes les activités réalisées (comme desktop)
                 return (
                   <div key={d.day} style={{ minWidth:0,display:'flex',flexDirection:'column',gap:3,alignItems:'center' }}>
                     <div style={{ width:'100%',textAlign:'center' as const,borderRadius:8,padding:'3px 0',boxSizing:'border-box' as const,background:today?'var(--bg)':'transparent',border:today?'1px solid var(--border-mid)':'1px solid transparent' }}>

--- a/src/components/planning/SessionEditor.tsx
+++ b/src/components/planning/SessionEditor.tsx
@@ -14,6 +14,7 @@
  * en haut du module planning/page.tsx avant le call site.
  */
 import React, { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { createClient } from '@/lib/supabase/client'
 import { useTrainingZones } from '@/hooks/useTrainingZones'
 import { segmentElevationProfile, getSignificantClimbs } from '@/lib/gpx/parser'
@@ -4671,8 +4672,13 @@ ${xTicks.map(km => { const x = PL+(km/totalKm)*pW; return `<line x1="${x.toFixed
       refs: { ftp: athleteData?.ftp ?? null, runThresholdPaceSec: athleteData?.runThresholdPaceSec ?? null, cssSecPer100m: athleteData?.cssSecPer100m ?? null },
       builderTab, setBuilderTab, saving, saved,
       onClose, onSave: handleSubmit, onExportPDF: handleExportPDF, onFavorite,
+      onDelete: isEdit && onDelete && session ? () => onDelete(session.id) : undefined,
     }
-    return wide ? <SessionEditorDesktop {...panelProps} /> : <SessionEditorMobile {...panelProps} />
+    // Portal vers document.body : sort des ancêtres transformés (MobileShell
+    // panelRef + framer-motion PageTransition) qui confinaient le position:fixed
+    // et laissaient des bandes noires en haut/bas. Couvre ainsi tout le viewport.
+    const panel = wide ? <SessionEditorDesktop {...panelProps} /> : <SessionEditorMobile {...panelProps} />
+    return typeof document !== 'undefined' ? createPortal(panel, document.body) : panel
   }
 
   return (

--- a/src/components/planning/mobile/PanelChrome.tsx
+++ b/src/components/planning/mobile/PanelChrome.tsx
@@ -1,7 +1,8 @@
 'use client'
 // Header + Footer partagés des coquilles SessionEditor (mobile & desktop).
 // Même look éditorial ; le footer peut être flottant (mobile) ou barre sticky (desktop).
-import { IconChevronLeft, IconFileText, IconStar } from '@tabler/icons-react'
+import { useState } from 'react'
+import { IconChevronLeft, IconFileText, IconStar, IconTrash } from '@tabler/icons-react'
 import { SPORT_LABEL } from '@/app/planning/page'
 import { PLAN_COLOR } from './editorial'
 import type { SessionEditorPanelProps } from './panelProps'
@@ -20,14 +21,28 @@ export function PanelHeader({ p, titleSize = 21, padding = '14px 18px', bordered
 }
 
 export function PanelFooter({ p, floating }: { p: SessionEditorPanelProps; floating?: boolean }) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
   const wrap: React.CSSProperties = floating
     ? { position: 'absolute', left: 0, right: 0, bottom: 0, padding: '12px 16px', paddingBottom: 'calc(14px + env(safe-area-inset-bottom))', pointerEvents: 'none' }
     : { flexShrink: 0, padding: '12px 20px', borderTop: '1px solid var(--se-rule)', background: 'var(--se-bg)' }
+
+  // Confirmation de suppression — remplace toute la barre.
+  if (confirmDelete && p.onDelete) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', ...wrap }}>
+        <span style={{ pointerEvents: 'auto', flex: 1, minWidth: 140, fontSize: 13.5, fontWeight: 600, color: 'var(--se-text)' }}>Supprimer cette séance ?</span>
+        <button type="button" onClick={() => setConfirmDelete(false)} style={footBtn}>Annuler</button>
+        <button type="button" onClick={p.onDelete} style={{ pointerEvents: 'auto', padding: '12px 22px', borderRadius: 999, border: 'none', background: 'var(--pat-hyrox)', color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', boxShadow: '0 4px 16px rgba(0,0,0,0.18)' }}>Supprimer</button>
+      </div>
+    )
+  }
+
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, ...wrap }}>
       <button type="button" onClick={p.onClose} style={footBtn}><IconChevronLeft size={15} /> Fermer</button>
       <button type="button" onClick={p.onExportPDF} style={footIcon} aria-label="Exporter en PDF"><IconFileText size={17} /></button>
       <button type="button" onClick={p.onFavorite} style={footIcon} aria-label="Enregistrer en favori"><IconStar size={17} /></button>
+      {p.onDelete && <button type="button" onClick={() => setConfirmDelete(true)} style={footDanger} aria-label="Supprimer la séance"><IconTrash size={17} /></button>}
       <div style={{ flex: 1 }} />
       <button type="button" onClick={p.onSave} disabled={p.saving} style={{ pointerEvents: 'auto', padding: '12px 24px', borderRadius: 999, border: 'none', background: p.accent, color: '#fff', fontSize: 14, fontWeight: 700, cursor: 'pointer', opacity: p.saving ? 0.6 : 1, boxShadow: '0 4px 16px rgba(0,0,0,0.18)' }}>
         {p.saved ? 'Enregistré ✓' : p.mode === 'create' ? 'Ajouter' : 'Enregistrer'} →
@@ -38,3 +53,4 @@ export function PanelFooter({ p, floating }: { p: SessionEditorPanelProps; float
 
 const footBtn: React.CSSProperties = { pointerEvents: 'auto', display: 'flex', alignItems: 'center', gap: 4, padding: '10px 15px', borderRadius: 999, border: '1px solid var(--se-rule)', background: 'var(--se-card)', color: 'var(--se-text)', fontSize: 13, fontWeight: 600, cursor: 'pointer', boxShadow: '0 2px 10px rgba(0,0,0,0.10)' }
 const footIcon: React.CSSProperties = { pointerEvents: 'auto', width: 40, height: 40, borderRadius: '50%', border: '1px solid var(--se-rule)', background: 'var(--se-card)', color: 'var(--se-text)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: '0 2px 10px rgba(0,0,0,0.10)' }
+const footDanger: React.CSSProperties = { ...footIcon, border: '1px solid var(--pat-hyrox)', color: 'var(--pat-hyrox)' }

--- a/src/components/planning/mobile/panelProps.ts
+++ b/src/components/planning/mobile/panelProps.ts
@@ -24,6 +24,7 @@ export interface SessionEditorPanelProps {
   builderTab: 'manual' | 'ai'; setBuilderTab: (t: 'manual' | 'ai') => void
   saving: boolean; saved: boolean
   onClose: () => void; onSave: () => void; onExportPDF: () => void; onFavorite: () => void
+  onDelete?: () => void
   // Muscu / Hyrox (builder par exercices) — sync vers les refs côté parent
   exercises: ExerciseItem[]; setExercises: (e: ExerciseItem[]) => void
   circuits: ExoCircuit[]; setCircuits: (c: ExoCircuit[]) => void


### PR DESCRIPTION
## Corrections Planning (mobile)
1. **Bandes noires haut/bas de l'éditeur de séance** → éditeur (mobile + desktop) rendu via `createPortal(document.body)`. `MobileShell` (page qui glisse) et `framer-motion` posaient un `transform` qui confinait le `position:fixed` entre les paddings du `<main>` ; le portal le sort de ces ancêtres et couvre tout le viewport.
2. **Activités réalisées invisibles sur mobile** → le mobile affiche désormais **toutes** les activités (comme le desktop) ; une séance réalisée rattachée à une activité ne disparaît plus.
3. **Bouton Supprimer + confirmation** ajouté au footer des panneaux éditoriaux (desktop **et** mobile).
4. **Bulles mobile** → titre sur 2 lignes (coupure propre) + durée·RPE non tronqués.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCYiE5gX8CK9LUniFfkrLb)_