### PR TITLE
Fix : suppression fiable des séances en masse + plan généré plus détaillé

### DIFF
--- a/src/app/api/coach-stream/route.ts
+++ b/src/app/api/coach-stream/route.ts
@@ -213,6 +213,7 @@ Tu disposes d'outils pour ÉCRIRE directement dans les pages de l'athlète. Util
 - log_body_weight / log_hydration / log_recovery_checkin : poids, hydratation, check-in récup (sommeil/fatigue/courbatures/humeur 1–5) dans la page Récupération.
 - add_race : ajoute une course/objectif au Calendrier. add_personal_record : ajoute un record dans la page Records.
 - create_route : CRÉE un vrai parcours GPS depuis la description de l'athlète (tu fournis les points/lieux à relier — villes, cols, sommets —, le routage suit les vraies routes et calcule distance + dénivelé). Pour un stage en plusieurs étapes, un appel par étape. Si un lieu/point de départ/région manque, demande-le d'abord (ask_clarifying_questions) — n'invente pas un lieu.
+- clear_planned_sessions : SUPPRIME des séances EN MASSE. Dès que l'athlète demande de supprimer TOUTES ses séances (ou toutes celles à venir), utilise CET outil (scope 'all' ou 'future'), PAS delete_session une par une (qui en oublie et peut prétendre à tort au succès). Il renvoie le nombre réellement supprimé : annonce ce nombre exact. delete_session ne sert qu'à retirer UNE séance précise.
 RÈGLES :
 1. N'écris QUE sur demande explicite de l'athlète. En cas de doute sur ce qu'il veut enregistrer, demande d'abord (ask_clarifying_questions), n'invente pas de valeurs.
 2. Utilise EN PRIORITÉ les données que tu viens de calculer/proposer dans la conversation (ne redemande pas ce que tu as déjà).

--- a/src/app/api/training-plan/route.ts
+++ b/src/app/api/training-plan/route.ts
@@ -537,14 +537,14 @@ ${modification ? `MODIFICATION DEMANDÉE :\n${modification}\n\nPROGRAMME EXISTAN
 INSTRUCTIONS DE GÉNÉRATION — RESPECTER IMPÉRATIVEMENT :
 
 STRUCTURE & DÉTAIL PROGRESSIF (méthode coach d'élite) — RÈGLE ABSOLUE DE TAILLE (sinon la génération échoue) :
-- Génère TOUTES les semaines de la durée demandée, mais ne détaille les SÉANCES que pour les 2 premières.
-- SEMAINES 1 et 2 UNIQUEMENT : seances[] complètes, avec blocs[] détaillés (échauffement → corps → retour au calme), zone, répétitions, récup et watts/allure/FC CALIBRÉS sur les zones de l'athlète (section ZONES D'ENTRAÎNEMENT).
-- SEMAINES 3 ET SUIVANTES : "seances": [] (TABLEAU VIDE OBLIGATOIRE). Ne génère AUCUNE séance pour ces semaines. Donne seulement : numero, type, volume_h, tss_semaine, theme (court), note_coach (1 phrase courte). Ces semaines seront détaillées plus tard, à l'approche. C'est ESSENTIEL pour que la génération aboutisse.
+- Génère TOUTES les semaines de la durée demandée, mais ne détaille les SÉANCES que pour les 3 premières.
+- SEMAINES 1 à 3 UNIQUEMENT : seances[] complètes, avec blocs[] détaillés (échauffement → corps → retour au calme), zone, répétitions, récup et watts/allure/FC CALIBRÉS sur les zones de l'athlète (section ZONES D'ENTRAÎNEMENT). JAMAIS de séance vague type « 3h vélo » : toujours la STRUCTURE (blocs, intensités chiffrées, reps, récup).
+- SEMAINES 4 ET SUIVANTES : "seances": [] (TABLEAU VIDE OBLIGATOIRE). Ne génère AUCUNE séance pour ces semaines. Donne seulement : numero, type, volume_h, tss_semaine, theme (court), note_coach (1 phrase courte). Ces semaines seront détaillées plus tard, à l'approche (l'athlète peut demander au coach de détailler une semaine précise à tout moment). C'est ESSENTIEL pour que la génération aboutisse.
 - note_coach : 1 phrase COURTE par semaine — le POURQUOI (objectif physiologique, place dans la périodisation).
 - conseils_adaptation : 3 à 4 maximum. points_cles : 3 à 4 maximum. Phrases courtes et concrètes.
 
 CALIBRAGE SUR LES DONNÉES RÉELLES :
-- Utilise les ZONES fournies pour prescrire des intensités chiffrées (watts vélo, allure run, FC) dans les blocs des semaines 1-2.
+- Utilise les ZONES fournies pour prescrire des intensités chiffrées (watts vélo, allure run, FC) dans les blocs des semaines 1-3.
 - Analyse l'HISTORIQUE 30 jours (volume, sports, charge) pour fixer un point de départ RÉALISTE.
 - Tiens compte des MÉTRIQUES santé récentes et des courses du CALENDRIER pour la périodisation et les volumes (début / progression / pic / affûtage).
 
@@ -606,7 +606,7 @@ RÈGLES GÉNÉRALES — RESPECTER ABSOLUMENT :
     const client = getAnthropicClient()
     const resp = await client.messages.create({
       model: MODELS.powerful,
-      max_tokens: 8000,
+      max_tokens: 12000,
       system: SYSTEM + JSON_ONLY,
       messages: [{ role: 'user', content: userPrompt }],
     })

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -69,6 +69,7 @@ const TOOL_STATUS_LABELS: Record<string, string> = {
   add_race:              'aip.tool.writePage',
   add_personal_record:   'aip.tool.writePage',
   create_route:          'aip.tool.createRoute',
+  clear_planned_sessions:'aip.tool.writePage',
   web_search:            'aip.tool.webSearch',
 }
 function toolStatusLabel(tools: string[] | undefined): string {

--- a/src/lib/coach/write-tools.ts
+++ b/src/lib/coach/write-tools.ts
@@ -82,6 +82,23 @@ export const writeTools: Anthropic.Tool[] = [
     },
   },
   {
+    name: 'clear_planned_sessions',
+    description:
+      "SUPPRIME des séances planifiées EN MASSE (page Planning). À utiliser quand l'athlète demande de supprimer " +
+      "TOUTES ses séances (scope 'all'), toutes celles à venir ('future'), ou une plage de dates ('range'). " +
+      "BEAUCOUP plus fiable que supprimer une par une (pas d'énumération d'ID, aucune séance oubliée). " +
+      "Renvoie le nombre RÉELLEMENT supprimé — annonce ce nombre à l'athlète (ne prétends pas au succès sans lui).",
+    input_schema: {
+      type: 'object',
+      properties: {
+        scope:     { type: 'string', enum: ['all', 'future', 'range'], description: "Portée (défaut 'all')." },
+        from_date: { type: 'string', description: "YYYY-MM-DD — début (scope 'range')." },
+        to_date:   { type: 'string', description: "YYYY-MM-DD — fin (scope 'range')." },
+        plan_id:   { type: 'string', description: "Limiter à un plan précis (UUID, optionnel)." },
+      },
+    },
+  },
+  {
     name: 'log_body_weight',
     description: "ÉCRIT le POIDS du jour dans la page Récupération (suivi corporel). Sur demande de l'athlète.",
     input_schema: {
@@ -218,6 +235,22 @@ export async function resolveWriteTool(
         const { error } = await sb.from('nutrition_daily_logs').upsert(rows, { onConflict: 'user_id,date' })
         if (error) return JSON.stringify({ ok: false, error: error.message })
         return JSON.stringify({ ok: true, page: 'Nutrition', days: rows.map(r => r.date) })
+      }
+
+      case 'clear_planned_sessions': {
+        const scope = input.scope === 'future' || input.scope === 'range' ? input.scope : 'all'
+        let q = sb.from('planned_sessions').delete().eq('user_id', userId)
+        if (scope === 'future') {
+          q = q.gte('week_start', today())
+        } else if (scope === 'range') {
+          const from = typeof input.from_date === 'string' ? input.from_date.slice(0, 10) : today()
+          const to = typeof input.to_date === 'string' ? input.to_date.slice(0, 10) : ymd(new Date(Date.now() + 365 * 86400000))
+          q = q.gte('week_start', from).lte('week_start', to)
+        }
+        if (typeof input.plan_id === 'string' && input.plan_id.trim()) q = q.eq('plan_id', input.plan_id.trim())
+        const { data, error } = await q.select('id')
+        if (error) return JSON.stringify({ ok: false, error: error.message })
+        return JSON.stringify({ ok: true, page: 'Planning', scope, deleted: (data ?? []).length })
       }
 
       case 'log_body_weight': {


### PR DESCRIPTION
## 1. Suppression en masse fiable (`clear_planned_sessions`)
L'IA disait « 12 modifications appliquées avec succès » mais les séances restaient : la suppression se faisait **une par une** par ID, et un `delete` sur un ID périmé / hors fenêtre efface **0 ligne sans renvoyer d'erreur** → faux succès (+ elle n'en récupérait que 12 dans une fenêtre de 28 jours).

**Nouvel outil** qui supprime **toutes** les séances (ou celles à venir / une plage) **en une seule requête serveur par `user_id`**, et renvoie le **nombre réellement supprimé**. Consigne : l'utiliser pour « supprime toutes mes séances », plus `delete_session` en boucle.

## 2. Plan généré plus détaillé
Le générateur ne détaillait que **2 semaines** (le reste vide) → séances vagues au-delà.
- Passe à **3 semaines détaillées**, budget **8000 → 12000 tokens**.
- **Interdit explicitement** les séances vagues (« 3h vélo ») : toujours **blocs + intensités chiffrées** (watts/allure/FC) + reps + récup.
- Les semaines suivantes restent des ébauches, **détaillables à la demande** via `add_week` (le coach génère les blocs complets quand tu le demandes).

## Fichiers
- `src/lib/coach/write-tools.ts` (`clear_planned_sessions`)
- `src/app/api/coach-stream/route.ts` (consigne), `src/app/api/training-plan/route.ts` (détail + budget)
- `src/components/ai/AIPanel.tsx` (libellé de statut)

## Vérification
- TypeScript strict : 0 erreur. RLS `planned_sessions` (ALL) vérifiée → la suppression serveur passe.
- À valider en prod : « supprime toutes mes séances » (doit tout retirer + annoncer le nombre) ; création d'un plan (séances détaillées avec watts/zones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMnddmw6NGosWs2RZ4Wa3c)_