### PR TITLE
Coach IA : champ « Instructions » + 5 presets pour piloter le style de l'IA

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1345,8 +1345,39 @@ function useAiRules() {
     setRules(p => p.filter(r => r.id !== id))
   }
 
-  return { rules, loading, addRule, toggleRule, deleteRule }
+  // Instruction personnelle unique (style/comportement de l'IA) — catégorie
+  // réservée 'instruction'. Upsert : on met à jour l'existante ou on crée.
+  async function saveInstruction(text: string) {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+    const trimmed = text.trim()
+    const existing = rules.find(r => r.category === 'instruction')
+    if (!trimmed) {
+      if (existing) { await supabase.from('ai_rules').delete().eq('id', existing.id); setRules(p => p.filter(r => r.id !== existing.id)) }
+      return
+    }
+    if (existing) {
+      await supabase.from('ai_rules').update({ rule_text: trimmed, active: true, updated_at: new Date().toISOString() }).eq('id', existing.id)
+      setRules(p => p.map(r => r.id === existing.id ? { ...r, rule_text: trimmed, active: true } : r))
+    } else {
+      const { data, error } = await supabase.from('ai_rules')
+        .insert({ user_id: user.id, category: 'instruction', rule_text: trimmed, active: true })
+        .select('id,category,rule_text,active,created_at').single()
+      if (!error && data) setRules(p => [...p, data as AiRule])
+    }
+  }
+
+  return { rules, loading, addRule, toggleRule, deleteRule, saveInstruction }
 }
+
+// Presets d'instruction — un tap pour définir le style de l'IA.
+const INSTRUCTION_PRESETS: { label: string; text: string }[] = [
+  { label: 'Coach exigeant', text: "Sois un coach exigeant et franc : aucune complaisance, tu me pousses, tu me reprends quand je me relâche, et tu vises la performance." },
+  { label: 'Pédagogue',      text: "Explique-moi toujours le POURQUOI de tes conseils, avec des mots simples, comme à quelqu'un qui veut comprendre et progresser." },
+  { label: 'Direct & concis', text: "Va droit au but : réponses courtes et concrètes, l'essentiel d'abord, sans introduction ni blabla." },
+  { label: 'Motivant',       text: "Sois positif et motivant : encourage-moi, valorise mes progrès, garde un ton énergique qui donne envie de m'entraîner." },
+  { label: 'Scientifique',   text: "Appuie tes conseils sur la science et mes données chiffrées (zones, charge, physiologie) ; explicite les principes quand c'est utile." },
+]
 
 // ── Composant RuleCreator — modal IA de formulation de règle ──
 function RuleCreator({ addRule, onClose }: {
@@ -1523,14 +1554,27 @@ function RuleCreator({ addRule, onClose }: {
 // ── Composant RulesCard ───────────────────────────────────────
 function RulesCard() {
   const { t } = useI18n()
-  const { rules, loading, addRule, toggleRule, deleteRule } = useAiRules()
+  const { rules, loading, addRule, toggleRule, deleteRule, saveInstruction } = useAiRules()
   const [activeTab,  setActiveTab]  = useState<string>('all')
   const [showModal,  setShowModal]  = useState(false)
   const [confirmDel, setConfirmDel] = useState<string|null>(null)
   const [hoveredId,  setHoveredId]  = useState<string|null>(null)
 
+  // ── Instruction personnelle (champ unique, façon Claude) ──
+  const instrRule = rules.find(r => r.category === 'instruction')
+  const [instr, setInstr] = useState('')
+  const [instrDirty, setInstrDirty] = useState(false)
+  const [instrSaved, setInstrSaved] = useState(false)
+  useEffect(() => { if (!instrDirty) setInstr(instrRule?.rule_text ?? '') }, [instrRule?.rule_text, instrDirty])
+  async function handleSaveInstruction() {
+    await saveInstruction(instr)
+    setInstrDirty(false); setInstrSaved(true); setTimeout(() => setInstrSaved(false), 1800)
+  }
+
   const catMeta = (id: string) => RULE_CATEGORIES.find(c => c.id === id) ?? { label: id, color: '#6b7280', icon: '📌', placeholder: '' }
-  const filtered = activeTab === 'all' ? rules : rules.filter(r => r.category === activeTab)
+  // La règle 'instruction' a son propre champ → on l'exclut de la liste des règles.
+  const listRules = rules.filter(r => r.category !== 'instruction')
+  const filtered = activeTab === 'all' ? listRules : listRules.filter(r => r.category === activeTab)
 
   async function handleDelete(id: string) {
     await deleteRule(id)
@@ -1549,6 +1593,43 @@ function RulesCard() {
         .rule-row { animation: ruleSlideIn 0.18s ease both }
         .rules-tabs::-webkit-scrollbar { display:none }
       `}</style>
+
+      {/* ── Instructions : prompt personnel qui définit le style de l'IA ── */}
+      <Card>
+        <CardTitle icon={<svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 2a7 7 0 00-4 12.7V17a1 1 0 001 1h6a1 1 0 001-1v-2.3A7 7 0 0012 2z"/><path d="M9 21h6"/></svg>}>Instructions</CardTitle>
+        <p style={{ fontSize:11, color:'var(--text-dim)', margin:'6px 0 12px', lineHeight:1.5 }}>
+          Un prompt qui dit à l&apos;IA comment se comporter et répondre. Il s&apos;applique à TOUTES tes conversations avec le coach.
+        </p>
+
+        {/* Presets — un tap pour insérer un style */}
+        <div style={{ display:'flex', gap:6, flexWrap:'wrap' as const, marginBottom:10 }}>
+          {INSTRUCTION_PRESETS.map(p => (
+            <button
+              key={p.label}
+              onClick={() => { setInstr(p.text); setInstrDirty(true) }}
+              style={{ padding:'5px 11px', borderRadius:20, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text-mid)', fontSize:11, fontWeight:600, cursor:'pointer', whiteSpace:'nowrap' as const }}
+            >{p.label}</button>
+          ))}
+        </div>
+
+        <textarea
+          value={instr}
+          onChange={e => { setInstr(e.target.value); setInstrDirty(true) }}
+          placeholder="Ex : Tu es mon coach personnel exigeant. Va à l'essentiel, appuie-toi sur mes données chiffrées, et pousse-moi à progresser."
+          rows={4}
+          style={{ width:'100%', boxSizing:'border-box' as const, padding:'11px 12px', borderRadius:12, border:'1px solid var(--border)', background:'var(--bg-card2)', color:'var(--text)', fontSize:13.5, lineHeight:1.5, fontFamily:'DM Sans,sans-serif', resize:'vertical' as const, outline:'none' }}
+        />
+        <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginTop:10 }}>
+          <span style={{ fontSize:11, color: instrSaved ? '#22c55e' : 'var(--text-dim)' }}>
+            {instrSaved ? '✓ Enregistré' : `${instr.length} caractères`}
+          </span>
+          <button
+            onClick={() => void handleSaveInstruction()}
+            disabled={!instrDirty}
+            style={{ padding:'8px 18px', borderRadius:10, border:'none', background: instrDirty ? 'linear-gradient(135deg,#06B6D4,#5b6fff)' : 'var(--border)', color:'#fff', fontSize:12.5, fontWeight:700, cursor: instrDirty ? 'pointer' : 'default' }}
+          >Enregistrer</button>
+        </div>
+      </Card>
 
       <Card>
         {/* Header */}

--- a/src/lib/agents/chatAgent.ts
+++ b/src/lib/agents/chatAgent.ts
@@ -272,23 +272,36 @@ export function buildChatParams(input: ChatInput) {
     ? formatContextForAgent(agentId, context)
     : ''
 
-  // Bloc règles personnalisées — injecté entre le system prompt de base et le contexte
+  // Bloc règles personnalisées — injecté entre le system prompt de base et le contexte.
+  // L'INSTRUCTION personnelle (catégorie réservée 'instruction') est hissée en
+  // tête, avec une consigne forte : elle définit le style/le ton/la manière de
+  // répondre du coach, et prime sur les formats par défaut.
+  let instructionBlock = ''
   let rulesBlock = ''
   if (aiRules && aiRules.length > 0) {
-    const grouped: Record<string, string[]> = {}
-    for (const r of aiRules) {
-      if (!grouped[r.category]) grouped[r.category] = []
-      grouped[r.category].push(r.rule_text)
+    const instr = aiRules.filter(r => r.category === 'instruction').map(r => r.rule_text.trim()).filter(Boolean).join('\n')
+    if (instr) {
+      instructionBlock = `\n\n═══════════ INSTRUCTION PERSONNELLE DE L'ATHLÈTE (PRIORITAIRE) ═══════════
+L'athlète a défini comment tu dois te comporter et répondre. Applique-la à CHAQUE réponse — c'est son coach sur-mesure. Elle prime sur les consignes de format par défaut (mais jamais sur les planchers de sécurité).
+${instr}`
     }
-    const sections = Object.entries(grouped)
-      .map(([cat, rules]) => `${CATEGORY_LABELS[cat] ?? cat} :\n${rules.map(r => `- ${r}`).join('\n')}`)
-      .join('\n\n')
-    rulesBlock = `\n\nRÈGLES PERSONNELLES DE L'ATHLÈTE — À RESPECTER IMPÉRATIVEMENT :\n${sections}`
+    const rest = aiRules.filter(r => r.category !== 'instruction')
+    if (rest.length > 0) {
+      const grouped: Record<string, string[]> = {}
+      for (const r of rest) {
+        if (!grouped[r.category]) grouped[r.category] = []
+        grouped[r.category].push(r.rule_text)
+      }
+      const sections = Object.entries(grouped)
+        .map(([cat, rules]) => `${CATEGORY_LABELS[cat] ?? cat} :\n${rules.map(r => `- ${r}`).join('\n')}`)
+        .join('\n\n')
+      rulesBlock = `\n\nRÈGLES PERSONNELLES DE L'ATHLÈTE — À RESPECTER IMPÉRATIVEMENT :\n${sections}`
+    }
   }
 
   const systemPrompt = contextBlock
-    ? `${baseSystem}${rulesBlock}\n\n${contextBlock}`
-    : `${baseSystem}${rulesBlock}`
+    ? `${baseSystem}${instructionBlock}${rulesBlock}\n\n${contextBlock}`
+    : `${baseSystem}${instructionBlock}${rulesBlock}`
   const anthropicMessages = messages.map(m => {
     if (typeof m.content === 'string') {
       return { role: m.role as 'user' | 'assistant', content: m.content }


### PR DESCRIPTION
## Objectif
Un endroit unique (profil, façon Claude) où l'athlète écrit un **prompt qui définit comment l'IA doit se comporter et répondre** — appliqué à **toutes** ses conversations avec le coach. Plus **5 presets** en un tap.

## Ce que ça ajoute
- **Champ « Instructions »** (textarea) dans le profil, section dédiée en haut de « Mes règles IA ».
- **5 presets** cliquables : *Coach exigeant · Pédagogue · Direct & concis · Motivant · Scientifique* — remplissent le champ, éditable ensuite.
- Stocké comme **règle réservée** (`ai_rules`, catégorie `instruction`, upsert unique), exclu de la liste des règles granulaires pour éviter le doublon.
- **Injection prioritaire** en tête du system prompt du coach : définit style/ton/manière de répondre, prime sur les formats par défaut (jamais sur les planchers de sécurité).

L'app avait déjà des « règles » catégorisées ; ceci ajoute le **champ unique et visible** demandé + les presets.

## Fichiers
- `src/app/profile/page.tsx` (champ + presets + save)
- `src/lib/agents/chatAgent.ts` (injection prioritaire de l'instruction)

## Vérification
- TypeScript strict : 0 erreur. `ai_rules` : RLS OK, **aucune contrainte de catégorie** (valeur `instruction` acceptée) — vérifié.
- À valider en prod : écrire une instruction (ou tap un preset) → Enregistrer → l'IA adopte le style dans les conversations suivantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMnddmw6NGosWs2RZ4Wa3c)_