### PR TITLE
Fix : sur-page Réglages IA laisse l'espace en haut

### DIFF
--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -22855,10 +22855,12 @@ export default function AIPanel({
               onClick={e => e.stopPropagation()}
               style={{
                 background: 'var(--bg)', color: 'var(--text)',
-                display: 'flex', flexDirection: 'column',
+                display: 'flex', flexDirection: 'column', overflow: 'hidden',
                 ...(isDesktop
                   ? { width: 'min(520px, 92vw)', height: '100%', borderLeft: '1px solid var(--border)', animation: 'iaset_side 0.28s cubic-bezier(0.32,0.72,0,1)' }
-                  : { width: '100%', maxHeight: '92vh', borderTopLeftRadius: 22, borderTopRightRadius: 22, animation: 'iaset_up 0.32s cubic-bezier(0.32,0.72,0,1)' }),
+                  // Sur-page mobile : ancrée en bas, laissant un ESPACE visible en haut
+                  // (fond flouté de l'interface IA), façon « Mon Profil ».
+                  : { position: 'fixed', left: 0, right: 0, bottom: 0, top: 'max(56px, calc(env(safe-area-inset-top, 0px) + 44px))', borderTopLeftRadius: 22, borderTopRightRadius: 22, boxShadow: '0 -10px 50px rgba(0,0,0,0.28)', animation: 'iaset_up 0.34s cubic-bezier(0.2,0.8,0.2,1)' }),
               }}
             >
               {/* En-tête */}


### PR DESCRIPTION
La sur-page « Réglages IA » couvrait tout l'écran. Elle est maintenant **ancrée en bas avec un espace visible en haut** (fond flouté de l'interface IA), exactement comme la sur-page « Mon Profil » — poignée, coins arrondis, tap sur le fond pour fermer.

- `src/components/ai/AIPanel.tsx` : `top: max(56px, safe-area+44px)` au lieu de `maxHeight: 92vh`.
- TypeScript strict : 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMnddmw6NGosWs2RZ4Wa3c)_