### PR TITLE
Phase 1 — génération sauvegardée côté serveur + reprise d'une réponse manquée

### DIFF
--- a/src/app/api/coach-runs/route.ts
+++ b/src/app/api/coach-runs/route.ts
@@ -1,0 +1,35 @@
+// ══════════════════════════════════════════════════════════════
+// GET /api/coach-runs?conv_id=…
+// Phase 1 — génération en arrière-plan : renvoie la DERNIÈRE réponse
+// du coach enregistrée côté serveur pour une conversation. Sert à
+// RETROUVER une réponse terminée pendant que l'app était fermée.
+// ══════════════════════════════════════════════════════════════
+
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(req: NextRequest) {
+  try {
+    const sb = await createClient()
+    const { data: { user } } = await sb.auth.getUser()
+    if (!user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+    const convId = req.nextUrl.searchParams.get('conv_id')
+    if (!convId) return NextResponse.json({ run: null })
+
+    const { data, error } = await sb.from('coach_runs')
+      .select('id,status,content,created_at')
+      .eq('user_id', user.id)
+      .eq('conv_id', convId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) return NextResponse.json({ run: null })
+
+    return NextResponse.json({ run: data ?? null })
+  } catch {
+    return NextResponse.json({ run: null })
+  }
+}

--- a/src/app/api/coach-stream/route.ts
+++ b/src/app/api/coach-stream/route.ts
@@ -713,6 +713,24 @@ APRÈS l'oral : un résumé SCHÉMATISÉ et aéré pour l'écran. CE N'EST PAS l
       // (le raisonnement peut manger tout le budget avant la réponse — voir max_tokens).
       let allowThinking = thinkingEnabled
 
+      // ── PHASE 1 — Génération en arrière-plan (persistance serveur) ──
+      // Chaque réponse du coach central est enregistrée dans coach_runs : la
+      // génération continue et se sauvegarde côté serveur, indépendamment de
+      // l'onglet. Si l'app se ferme, la réponse est retrouvable en base.
+      const persistRun = (chatBody as { agentId?: string }).agentId === 'central'
+      const convIdForRun = (chatBody as { convId?: string }).convId ?? null
+      let runId: string | null = null
+      let fullText = ''
+      let runErrored = false
+      if (persistRun) {
+        try {
+          const { data } = await sbForTools.from('coach_runs')
+            .insert({ user_id: userId, conv_id: convIdForRun, status: 'running', model: chatModel })
+            .select('id').single()
+          runId = (data as { id: string } | null)?.id ?? null
+        } catch (e) { console.error('[coach-stream] coach_runs insert failed:', e) }
+      }
+
       try {
         for (let step = 0; step < MAX_STEPS; step++) {
           const ms = client.messages.stream({
@@ -730,6 +748,7 @@ APRÈS l'oral : un résumé SCHÉMATISÉ et aéré pour l'écran. CE N'EST PAS l
           for await (const ev of ms) {
             if (ev.type === 'content_block_delta' && ev.delta.type === 'text_delta' && ev.delta.text) {
               send('text', JSON.stringify(ev.delta.text))
+              fullText += ev.delta.text
             } else if (ev.type === 'content_block_delta' && ev.delta.type === 'thinking_delta' && ev.delta.thinking) {
               // Raisonnement étendu en direct → feuille « Processus de réflexion »
               send('thinking', JSON.stringify(ev.delta.thinking))
@@ -858,7 +877,15 @@ APRÈS l'oral : un résumé SCHÉMATISÉ et aéré pour l'écran. CE N'EST PAS l
         const msg = e instanceof Error ? e.message : String(e)
         console.error('[coach-stream] agentic loop error:', msg)
         send('text', JSON.stringify(`\n\n⚠️ IA : ${msg}`))
+        runErrored = true
+        if (runId) {
+          try { await sbForTools.from('coach_runs').update({ status: 'error', content: fullText, error: msg, updated_at: new Date().toISOString() }).eq('id', runId) } catch { /* best-effort */ }
+        }
       } finally {
+        // Réponse finalisée côté serveur (retrouvable même si l'app s'est fermée).
+        if (runId && !runErrored) {
+          try { await sbForTools.from('coach_runs').update({ status: 'done', content: fullText, updated_at: new Date().toISOString() }).eq('id', runId) } catch { /* best-effort */ }
+        }
         streamClosed = true
         clearInterval(heartbeat)
         controller.close()

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -19632,6 +19632,36 @@ export default function AIPanel({
 
   const active = convs.find(c => c.id === activeId) ?? null
 
+  // ── PHASE 1 — Reprise d'une réponse générée en arrière-plan ──
+  // Si on rouvre une conversation dont le DERNIER message est de l'utilisateur
+  // (la réponse du coach est arrivée pendant que l'app était fermée), on va la
+  // chercher côté serveur (coach_runs) et on l'affiche. Cas ciblé et sûr :
+  // on n'ajoute une réponse QUE s'il en manque visiblement une.
+  const resumedConvRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    if (!active || loading) return
+    const msgs = active.msgs
+    const last = msgs[msgs.length - 1]
+    if (!last || last.role !== 'user') return          // une réponse manque-t-elle ?
+    if (resumedConvRef.current.has(active.id)) return   // déjà tenté pour cette conv
+    resumedConvRef.current.add(active.id)
+    const convId = active.id
+    void (async () => {
+      try {
+        const res = await fetch(`/api/coach-runs?conv_id=${encodeURIComponent(convId)}`)
+        if (!res.ok) return
+        const { run } = await res.json() as { run: { status: string; content: string } | null }
+        if (!run || run.status !== 'done' || !run.content?.trim()) return
+        setConvs(prev => prev.map(c => {
+          if (c.id !== convId) return c
+          const l = c.msgs[c.msgs.length - 1]
+          if (!l || l.role !== 'user') return c          // re-vérifie (évite tout doublon)
+          return { ...c, msgs: [...c.msgs, { id: genId(), role: 'assistant' as const, content: run.content, ts: Date.now(), modelId: model }], updatedAt: Date.now() }
+        }))
+      } catch { /* silencieux */ }
+    })()
+  }, [active, loading, model])
+
   // ── Effects ────────────────────────────────────────────────
 
   // Ferme le dropdown agent au clic extérieur

--- a/src/supabase/migrations/add_coach_runs.sql
+++ b/src/supabase/migrations/add_coach_runs.sql
@@ -1,0 +1,39 @@
+-- ══════════════════════════════════════════════════════════════
+-- Phase 1 — Génération en arrière-plan : chaque réponse du coach
+-- central est enregistrée côté serveur (coach_runs), indépendamment
+-- de l'onglet. Permet de retrouver une réponse terminée pendant que
+-- l'app était fermée. RLS stricte (chaque athlète ne voit que ses runs).
+-- ══════════════════════════════════════════════════════════════
+
+create table if not exists public.coach_runs (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  conv_id    text,
+  status     text not null default 'running',   -- running | done | error
+  content    text default '',
+  model      text,
+  error      text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists coach_runs_user_conv_idx
+  on public.coach_runs(user_id, conv_id, created_at desc);
+
+alter table public.coach_runs enable row level security;
+
+do $$
+begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='coach_runs' and policyname='coach_runs_select_own') then
+    create policy "coach_runs_select_own" on public.coach_runs for select using (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='coach_runs' and policyname='coach_runs_insert_own') then
+    create policy "coach_runs_insert_own" on public.coach_runs for insert with check (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='coach_runs' and policyname='coach_runs_update_own') then
+    create policy "coach_runs_update_own" on public.coach_runs for update using (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='coach_runs' and policyname='coach_runs_delete_own') then
+    create policy "coach_runs_delete_own" on public.coach_runs for delete using (auth.uid() = user_id);
+  end if;
+end $$;


### PR DESCRIPTION
Première brique du #1 (génération en arrière-plan), **additive et non-cassante**.

## Ce que ça fait
- **Persistance serveur** : chaque réponse du coach central est enregistrée dans `coach_runs` (`running` → `done`/`error`, contenu accumulé), **indépendamment de l'onglet**.
- **`GET /api/coach-runs?conv_id=…`** : renvoie la dernière réponse enregistrée d'une conversation.
- **Reprise côté client** : si tu rouvres une conversation dont le **dernier message est de toi** (la réponse est arrivée pendant que l'app était fermée), l'app va la chercher en base et l'affiche. Cas **ciblé et sûr** : n'ajoute une réponse que s'il en manque visiblement une (double garde anti-doublon + `resumedConvRef`).

## Fichiers
- `src/supabase/migrations/add_coach_runs.sql` (migration **appliquée** en prod, RLS stricte)
- `src/app/api/coach-stream/route.ts` (création + finalisation du run)
- `src/app/api/coach-runs/route.ts` (lecture)
- `src/components/ai/AIPanel.tsx` (reprise ciblée)

## Vérification
- TypeScript strict : 0 erreur. RLS `coach_runs` vérifiée.
- À valider en prod : pose une question, **ferme l'app** avant la fin, rouvre → la réponse doit apparaître.

## Suite (Phase 1.2)
Reprendre une génération **encore en cours** (status `running`, contenu partiel + reprise live) et afficher le **statut « en cours »** dans la sidebar. Puis Phase 2 (multi-chats) et Phase 3 (push).

⚠️ Limite connue : la persistance dépend de la fin de la génération côté serveur ; si la plateforme coupe la fonction à la fermeture, la Phase 1.2 (exécution détachée via file d'attente) complètera la robustesse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMnddmw6NGosWs2RZ4Wa3c)_