### PR TITLE
Notifications : moteur central + déclencheurs réels (in-app + push)

### DIFF
--- a/src/app/api/notifications/dispatch/route.ts
+++ b/src/app/api/notifications/dispatch/route.ts
@@ -1,0 +1,128 @@
+// ══════════════════════════════════════════════════════════════
+// CRON quotidien des notifications à base de DATE / HEURE.
+// Déclenché par Vercel Cron (gardé par CRON_SECRET, comme /api/coach/learn).
+//
+// Couvre : compétitions J-7/J-3/J-1, recharge glucidique avant course,
+// séance du jour, programme du matin, rappel HRV, hydratation, rappel repas,
+// résumé hebdo (lundi) / mensuel (1er), astuce du jour, plan en expiration.
+//
+// Chaque envoi passe par notifyUser() → respecte le toggle de l'utilisateur
+// et écrit à la fois la notif in-app (cloche) et le push.
+// ══════════════════════════════════════════════════════════════
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 120
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/server'
+import { notifyUser } from '@/lib/notifications/dispatch'
+
+const DAY = 86400000
+function ymd(d: Date): string { return d.toISOString().slice(0, 10) }
+
+// Astuces du jour (rotation par jour de l'année).
+const TIPS: string[] = [
+  'Note ton ressenti après chaque séance : le coach affine ses conseils.',
+  'Un échauffement de 10 min réduit nettement le risque de blessure.',
+  'La régularité bat l’intensité : mieux vaut 4 séances tenues qu’une séance parfaite.',
+  'Bois avant d’avoir soif, surtout les jours de grosse charge.',
+  'Le sommeil est ton meilleur outil de récupération. Vise la régularité.',
+  'Analyse une de tes activités avec le coach pour repérer un axe de progrès.',
+  'Varie les intensités : le facile doit être vraiment facile, le dur vraiment dur.',
+]
+
+export async function GET(req: NextRequest) {
+  const secret = process.env.CRON_SECRET
+  const auth = req.headers.get('authorization')
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sb = createServiceClient()
+  const now = new Date()
+  const today = ymd(now)
+  const plus = (n: number) => ymd(new Date(now.getTime() + n * DAY))
+  const mondayIdx = (now.getUTCDay() + 6) % 7        // lundi = 0 … dimanche = 6
+  const weekStart = ymd(new Date(now.getTime() - mondayIdx * DAY))
+  const isMonday = mondayIdx === 0
+  const isFirstOfMonth = now.getUTCDate() === 1
+  const dayOfYear = Math.floor((now.getTime() - Date.UTC(now.getUTCFullYear(), 0, 0)) / DAY)
+
+  // Seuls les utilisateurs avec au moins un appareil abonné (ou qui verront
+  // la cloche) comptent. On part des abonnements push pour borner la charge.
+  const { data: subs } = await sb.from('push_subscriptions').select('user_id')
+  const userIds = Array.from(new Set(((subs ?? []) as Array<{ user_id: string }>).map(s => s.user_id))).filter(Boolean)
+  if (userIds.length === 0) return NextResponse.json({ ok: true, users: 0, sent: 0 })
+
+  let sent = 0
+  const fire = async (uid: string, key: Parameters<typeof notifyUser>[1], payload: Parameters<typeof notifyUser>[2]) => {
+    try { await notifyUser(uid, key, payload); sent++ } catch { /* best-effort */ }
+  }
+
+  // ── 1. Compétitions J-7 / J-3 / J-1 + recharge glucidique J-2/J-1 ──
+  try {
+    const { data: races } = await sb.from('planned_races')
+      .select('user_id,name,date')
+      .in('user_id', userIds)
+      .in('date', [plus(1), plus(2), plus(3), plus(7)])
+    for (const r of (races ?? []) as Array<{ user_id: string; name: string | null; date: string }>) {
+      const uid = r.user_id
+      const name = r.name || 'Ta compétition'
+      if (r.date === plus(7)) {
+        await fire(uid, 'competitions.j7', { title: 'Compétition dans 7 jours', body: `${name} approche. On peaufine les derniers réglages.`, url: '/planning', dedupKey: `comp-j7-${r.date}-${name}`, once: true })
+      } else if (r.date === plus(3)) {
+        await fire(uid, 'competitions.j3', { title: 'Compétition dans 3 jours', body: `${name} : derniers préparatifs.`, url: '/planning', dedupKey: `comp-j3-${r.date}-${name}`, once: true })
+      } else if (r.date === plus(1)) {
+        await fire(uid, 'competitions.j1', { title: "C'est demain !", body: `${name} a lieu demain. Repos et confiance 💪`, url: '/planning', dedupKey: `comp-j1-${r.date}-${name}`, once: true })
+      }
+      if (r.date === plus(1) || r.date === plus(2)) {
+        await fire(uid, 'nutrition.recharge_glucidique', { title: 'Recharge glucidique', body: `${name} approche : pense à recharger tes réserves de glycogène.`, url: '/nutrition', dedupKey: `recharge-${r.date}-${name}`, once: true })
+      }
+    }
+  } catch { /* best-effort */ }
+
+  // ── 2. Séance planifiée du jour ──
+  try {
+    const { data: sessions } = await sb.from('planned_sessions')
+      .select('user_id,title,sport,time,status,day_index')
+      .in('user_id', userIds)
+      .eq('week_start', weekStart)
+      .eq('day_index', mondayIdx)
+    for (const s of (sessions ?? []) as Array<{ user_id: string; title: string | null; sport: string | null; time: string | null; status: string | null }>) {
+      if (s.status === 'done' || s.status === 'skipped') continue
+      const label = s.title || (s.sport ? `Séance ${s.sport}` : 'Séance du jour')
+      await fire(s.user_id, 'entrainement.rappel_seance', { title: 'Séance du jour', body: `${label}${s.time ? ` — ${s.time}` : ''}`, url: '/planning', dedupKey: `seance-${today}`, })
+    }
+  } catch { /* best-effort */ }
+
+  // ── 3. Plan / essai en expiration (~3 jours) ──
+  try {
+    const { data: subsRows } = await sb.from('user_subscriptions')
+      .select('user_id,current_period_end,trial_ends_at,status,cancel_at_period_end')
+      .in('user_id', userIds)
+    for (const s of (subsRows ?? []) as Array<{ user_id: string; current_period_end: string | null; trial_ends_at: string | null; status: string | null; cancel_at_period_end: boolean | null }>) {
+      const trialEnd = s.trial_ends_at ? s.trial_ends_at.slice(0, 10) : null
+      const periodEnd = s.current_period_end ? s.current_period_end.slice(0, 10) : null
+      const trialEnding = s.status === 'trialing' && trialEnd && (trialEnd === plus(3) || trialEnd === plus(1))
+      const subEnding = s.cancel_at_period_end && periodEnd && (periodEnd === plus(3) || periodEnd === plus(1))
+      if (trialEnding || subEnding) {
+        const endDate = trialEnding ? trialEnd! : periodEnd!
+        await fire(s.user_id, 'tokens.plan_expiration', { title: 'Ton abonnement arrive à échéance', body: trialEnding ? 'Ta période d’essai se termine bientôt.' : 'Ton abonnement se termine bientôt.', url: '/settings/subscription', dedupKey: `expire-${endDate}`, once: true })
+      }
+    }
+  } catch { /* best-effort */ }
+
+  // ── 4. Rappels quotidiens (à tous, filtrés par préférence individuelle) ──
+  for (const uid of userIds) {
+    await fire(uid, 'entrainement.programme_matin', { title: 'Ton programme du jour', body: 'Ouvre ton briefing du matin pour voir le plan du jour.', url: '/briefing', dedupKey: `matin-${today}` })
+    await fire(uid, 'recuperation.rappel_hrv', { title: 'Mesure HRV', body: 'Pense à mesurer ta HRV au réveil pour ajuster ta charge.', url: '/recovery', dedupKey: `hrv-${today}` })
+    await fire(uid, 'nutrition.hydratation', { title: 'Hydratation', body: "Objectif du jour : bien t'hydrater 💧", url: '/nutrition', dedupKey: `hydra-${today}` })
+    await fire(uid, 'nutrition.rappel_repas', { title: 'Repas', body: 'Pense à bien répartir tes repas et tes apports aujourd’hui.', url: '/nutrition', dedupKey: `repas-${today}` })
+    await fire(uid, 'systeme.astuce', { title: 'Astuce du jour', body: TIPS[dayOfYear % TIPS.length], url: '/', dedupKey: `astuce-${today}` })
+    if (isMonday) await fire(uid, 'performance.resume_hebdo', { title: 'Résumé de la semaine', body: 'Ton bilan charge & progression de la semaine est prêt.', url: '/performance', dedupKey: `hebdo-${today}`, once: true })
+    if (isFirstOfMonth) await fire(uid, 'performance.resume_mensuel', { title: 'Résumé du mois', body: 'Ta synthèse mensuelle est disponible.', url: '/performance', dedupKey: `mensuel-${today}`, once: true })
+  }
+
+  return NextResponse.json({ ok: true, users: userIds.length, sent })
+}

--- a/src/app/api/notifications/emit/route.ts
+++ b/src/app/api/notifications/emit/route.ts
@@ -1,0 +1,46 @@
+// ══════════════════════════════════════════════════════════════
+// POST /api/notifications/emit
+// Émet une notification pour l'utilisateur CONNECTÉ (in-app + push),
+// depuis un événement déclenché côté client (plan sauvegardé, analyse
+// terminée, compétence activée…). La clé doit appartenir au catalogue.
+// ══════════════════════════════════════════════════════════════
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { notifyUser } from '@/lib/notifications/dispatch'
+import { NOTIF_DEFAULTS, type NotifKey } from '@/lib/notifications/catalog'
+
+export async function POST(req: NextRequest) {
+  try {
+    const sb = await createClient()
+    const { data: { user } } = await sb.auth.getUser()
+    if (!user) return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+
+    const body = await req.json().catch(() => null) as
+      | { key?: string; title?: string; body?: string; url?: string; dedupKey?: string; once?: boolean }
+      | null
+    const key = body?.key
+    if (!key || !(key in NOTIF_DEFAULTS)) {
+      return NextResponse.json({ error: 'Clé de notification inconnue' }, { status: 400 })
+    }
+    if (!body?.title || !body?.body) {
+      return NextResponse.json({ error: 'title et body requis' }, { status: 400 })
+    }
+
+    // Fire-and-forget : la réponse ne dépend pas de la livraison du push.
+    void notifyUser(user.id, key as NotifKey, {
+      title: body.title,
+      body: body.body,
+      url: body.url,
+      dedupKey: body.dedupKey,
+      once: body.once,
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Erreur' }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import type Stripe from 'stripe'
 import { stripe, getTierFromPriceId } from '@/lib/stripe/config'
 import { createServiceClient } from '@/lib/supabase/server'
+import { notifyUser } from '@/lib/notifications/dispatch'
 import type { TierName } from '@/lib/subscriptions/tier-limits'
 
 // ── Helpers ────────────────────────────────────────────────────
@@ -171,6 +172,14 @@ export async function POST(req: NextRequest) {
         await sb.from('user_subscriptions').update({
           status: 'past_due',
         }).eq('user_id', subRow.user_id)
+
+        void notifyUser(subRow.user_id, 'tokens.paiement_echoue', {
+          title: 'Paiement échoué',
+          body: 'Ton dernier paiement n’a pas abouti. Mets à jour ton moyen de paiement pour garder ton accès.',
+          url: '/settings/subscription',
+          dedupKey: `payfail-${invoice.id}`,
+          once: true,
+        })
 
         console.log(`[stripe/webhook] invoice.payment_failed → user ${subRow.user_id} → past_due`)
         break

--- a/src/app/api/sync/[provider]/route.ts
+++ b/src/app/api/sync/[provider]/route.ts
@@ -17,6 +17,7 @@ import {
   syncPolarNightlyRecharge,
 } from '@/lib/sync/polar'
 import { callPolarV4, polarDateRange } from '@/lib/polar'
+import { notifyUser } from '@/lib/notifications/dispatch'
 
 export async function POST(
   req: NextRequest,
@@ -119,6 +120,15 @@ export async function POST(
             .eq('id', log.id)
         }
 
+        if (count > 0) {
+          void notifyUser(userId, 'connexions.activite_synchro', {
+            title: 'Nouvelle activité importée',
+            body: `${count} nouvelle${count > 1 ? 's' : ''} activité${count > 1 ? 's' : ''} importée${count > 1 ? 's' : ''} depuis Polar.`,
+            url: '/data',
+            dedupKey: `sync-polar-${new Date().toISOString().slice(0, 10)}`,
+          })
+        }
+
         return NextResponse.json({
           success:  true,
           synced:   count,
@@ -149,6 +159,15 @@ export async function POST(
         .eq('id', log.id)
     }
 
+    if (count > 0) {
+      void notifyUser(userId, 'connexions.activite_synchro', {
+        title: 'Nouvelle activité importée',
+        body: `${count} nouvelle${count > 1 ? 's' : ''} activité${count > 1 ? 's' : ''} importée${count > 1 ? 's' : ''} depuis ${provider}.`,
+        url: '/data',
+        dedupKey: `sync-${provider}-${new Date().toISOString().slice(0, 10)}`,
+      })
+    }
+
     return NextResponse.json({ success: true, synced: count })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -157,6 +176,12 @@ export async function POST(
         .update({ status: 'error', error_message: msg, completed_at: new Date().toISOString() })
         .eq('id', log.id)
     }
+    void notifyUser(userId, 'connexions.echec_sync', {
+      title: 'Échec de synchronisation',
+      body: `La synchronisation ${provider} a échoué. Réessaie depuis tes connexions.`,
+      url: '/connections',
+      dedupKey: `syncfail-${provider}-${new Date().toISOString().slice(0, 10)}`,
+    })
     return NextResponse.json({ error: msg }, { status: 500 })
   }
 }

--- a/src/app/api/topup/webhook/route.ts
+++ b/src/app/api/topup/webhook/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase/server'
 import { stripe } from '@/lib/stripe/config'
+import { notifyUser } from '@/lib/notifications/dispatch'
 import type Stripe from 'stripe'
 
 export const dynamic = 'force-dynamic'
@@ -57,6 +58,15 @@ export async function POST(req: Request) {
         .update({ used_at: new Date().toISOString() })
         .eq('user_id', userId)
         .is('used_at', null)
+
+      // Notification : pack de tokens crédité.
+      void notifyUser(userId, 'tokens.pack_credite', {
+        title: 'Tokens ajoutés ✅',
+        body: `${tokensAmount.toLocaleString('fr-FR')} tokens ont été crédités sur ton compte.`,
+        url: '/settings/subscription',
+        dedupKey: `pack-${purchaseId}`,
+        once: true,
+      })
     }
   }
 

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -19,6 +19,7 @@ import { CheckCircle2, XCircle, ChevronDown, ChevronRight, ArrowLeft, Zap, Globe
 import HybridNetworksPanel, { type HNConv } from './HybridNetworksPanel'
 import { MobileSheet } from './MobileSheet'
 import { haptic } from '@/lib/ui/haptic'
+import { emitNotification } from '@/lib/notifications/emit'
 import { VoiceOverlay } from './VoiceOverlay'
 import { VoiceConversation } from './VoiceConversation'
 import { CoachQuestionCard, type ClarifyingQuestions } from './CoachQuestionCard'
@@ -8304,6 +8305,7 @@ function TrainingPlanFlow({
           .limit(1)
           .maybeSingle()
         planId = planRow?.id as string | undefined
+        emitNotification({ key: 'entrainement.nouveau_plan', title: 'Nouveau plan prêt', body: `${planName} a été ajouté à ton planning.`, url: '/planning', dedupKey: planId ? `plan-${planId}` : undefined, once: true })
       }
 
       // 3. Construire la liste des séances à insérer

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -19696,29 +19696,78 @@ export default function AIPanel({
   // chercher côté serveur (coach_runs) et on l'affiche. Cas ciblé et sûr :
   // on n'ajoute une réponse QUE s'il en manque visiblement une.
   const resumedConvRef = useRef<Set<string>>(new Set())
-  useEffect(() => {
-    if (!active || loading) return
-    const msgs = active.msgs
-    const last = msgs[msgs.length - 1]
-    if (!last || last.role !== 'user') return          // une réponse manque-t-elle ?
-    if (resumedConvRef.current.has(active.id)) return   // déjà tenté pour cette conv
-    resumedConvRef.current.add(active.id)
-    const convId = active.id
-    void (async () => {
+  // Vrai tant que le composant est monté : coupe les pollers en cours au démontage.
+  const pollAliveRef = useRef(true)
+  useEffect(() => { pollAliveRef.current = true; return () => { pollAliveRef.current = false } }, [])
+
+  // Ajoute une réponse terminée à une conversation (garde anti-doublon : ne le
+  // fait QUE si le dernier message est encore celui de l'utilisateur).
+  const appendResumedResponse = useCallback((convId: string, content: string) => {
+    setConvs(prev => prev.map(c => {
+      if (c.id !== convId) return c
+      const l = c.msgs[c.msgs.length - 1]
+      if (!l || l.role !== 'user') return c
+      return { ...c, msgs: [...c.msgs, { id: genId(), role: 'assistant' as const, content, ts: Date.now(), modelId: model }], updatedAt: Date.now() }
+    }))
+  }, [model])
+
+  // Interroge coach_runs jusqu'à ce que la génération (démarrée dans une session
+  // précédente, puis retrouvée après un reload) se termine, puis affiche la
+  // réponse et retire le spinner.
+  const pollRunningRun = useCallback((convId: string) => {
+    let attempts = 0
+    const MAX = 80  // ~4 min à 3 s d'intervalle (garde-fou)
+    const tick = async () => {
+      if (!pollAliveRef.current) return
+      attempts++
       try {
         const res = await fetch(`/api/coach-runs?conv_id=${encodeURIComponent(convId)}`)
-        if (!res.ok) return
-        const { run } = await res.json() as { run: { status: string; content: string } | null }
-        if (!run || run.status !== 'done' || !run.content?.trim()) return
-        setConvs(prev => prev.map(c => {
-          if (c.id !== convId) return c
-          const l = c.msgs[c.msgs.length - 1]
-          if (!l || l.role !== 'user') return c          // re-vérifie (évite tout doublon)
-          return { ...c, msgs: [...c.msgs, { id: genId(), role: 'assistant' as const, content: run.content, ts: Date.now(), modelId: model }], updatedAt: Date.now() }
-        }))
-      } catch { /* silencieux */ }
-    })()
-  }, [active, loading, model])
+        if (res.ok) {
+          const { run } = await res.json() as { run: { status: string; content: string } | null }
+          if (run && run.status === 'done') {
+            if (run.content?.trim()) appendResumedResponse(convId, run.content)
+            endGen(convId, true)
+            return
+          }
+          if (run && run.status === 'error') { endGen(convId); return }
+        }
+      } catch { /* réessaie au prochain tick */ }
+      if (attempts >= MAX) { endGen(convId); return }
+      setTimeout(() => void tick(), 3000)
+    }
+    void tick()
+  }, [appendResumedResponse, endGen])
+
+  // Scan au chargement (et après fusion multi-appareils) : pour chaque conv dont
+  // le DERNIER message est de l'utilisateur (réponse manquante), on interroge
+  // coach_runs. Réponse « done » arrivée app fermée → on l'affiche ; génération
+  // encore « running » (reprise après reload) → spinner + poll jusqu'à la fin.
+  useEffect(() => {
+    if (!mounted) return
+    for (const c of convs) {
+      if (generatingConvs.has(c.id)) continue        // déjà suivie cette session
+      if (resumedConvRef.current.has(c.id)) continue // déjà tentée
+      const last = c.msgs[c.msgs.length - 1]
+      if (!last || last.role !== 'user') continue    // réponse présente → rien à faire
+      resumedConvRef.current.add(c.id)
+      const convId = c.id
+      void (async () => {
+        try {
+          const res = await fetch(`/api/coach-runs?conv_id=${encodeURIComponent(convId)}`)
+          if (!res.ok) return
+          const { run } = await res.json() as { run: { status: string; content: string } | null }
+          if (!run) return
+          if (run.status === 'done') {
+            if (run.content?.trim()) appendResumedResponse(convId, run.content)
+          } else if (run.status === 'running') {
+            startGen(convId)          // ré-affiche le spinner « réflexion »
+            pollRunningRun(convId)    // reprend jusqu'à la fin
+          }
+        } catch { /* silencieux */ }
+      })()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [convs, mounted])
 
   // ── Effects ────────────────────────────────────────────────
 

--- a/src/hooks/useAIAnalysis.ts
+++ b/src/hooks/useAIAnalysis.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export type AIStatus = 'idle' | 'loading' | 'streaming' | 'done' | 'error'
 
@@ -42,6 +43,7 @@ export function useAIAnalysis() {
         setText(prev => prev + decoder.decode(value, { stream: true }))
       }
       setStatus('done')
+      emitNotification({ key: 'coach.analyse_terminee', title: 'Analyse terminée', body: 'Ton analyse est prête à consulter.', url: '/' })
     } catch {
       setStatus('error')
     }

--- a/src/hooks/useNutrition.ts
+++ b/src/hooks/useNutrition.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useEffect, useCallback } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export type MealKey = 'petit_dejeuner' | 'collation_matin' | 'dejeuner' | 'collation_apres_midi' | 'diner' | 'collation_soir'
 export type MealTiming = 'pre_training' | 'post_training' | 'rest' | 'morning' | 'evening'
@@ -146,6 +147,7 @@ export function useNutrition() {
     if (!user) return
     await supabase.from('nutrition_plans').update({ actif: false }).eq('user_id', user.id)
     await supabase.from('nutrition_plans').insert({ user_id: user.id, type, plan_data: planData, actif: true })
+    emitNotification({ key: 'nutrition.plan_nutrition', title: 'Plan nutritionnel prêt', body: 'Ton nouveau plan nutrition est disponible.', url: '/nutrition' })
     await load()
   }
 

--- a/src/lib/notifications/catalog.ts
+++ b/src/lib/notifications/catalog.ts
@@ -1,0 +1,72 @@
+// ══════════════════════════════════════════════════════════════
+// Catalogue serveur des notifications : clés STABLES « catégorie.nom »
+// + valeur par défaut (utilisée quand l'utilisateur n'a jamais touché le
+// toggle). DOIT rester aligné avec NOTIF_CATEGORIES (src/app/profile/page.tsx).
+// ══════════════════════════════════════════════════════════════
+
+export type NotifKey =
+  | 'entrainement.rappel_seance' | 'entrainement.programme_matin' | 'entrainement.seance_a_venir'
+  | 'entrainement.nouveau_plan' | 'entrainement.rappel_enregistrement' | 'entrainement.test_suggere'
+  | 'recuperation.rappel_hrv' | 'recuperation.suivi_sommeil' | 'recuperation.alerte_fatigue'
+  | 'recuperation.recup_recommandee' | 'recuperation.conseils_post_seance'
+  | 'nutrition.rappel_repas' | 'nutrition.hydratation' | 'nutrition.timing_nutritionnel'
+  | 'nutrition.recharge_glucidique' | 'nutrition.plan_nutrition'
+  | 'performance.resume_hebdo' | 'performance.resume_mensuel' | 'performance.progression'
+  | 'performance.evolution_charge' | 'performance.zones_maj'
+  | 'coach.suggestions' | 'coach.briefing' | 'coach.analyse_terminee' | 'coach.competences'
+  | 'tokens.quota_80' | 'tokens.quota_95' | 'tokens.quota_epuise' | 'tokens.pack_credite'
+  | 'tokens.plan_expiration' | 'tokens.paiement_echoue'
+  | 'connexions.activite_synchro' | 'connexions.donnee_importee' | 'connexions.reconnexion'
+  | 'connexions.echec_sync'
+  | 'competitions.j7' | 'competitions.j3' | 'competitions.j1' | 'competitions.strategie_dispo'
+  | 'systeme.nouvelle_version' | 'systeme.nouvelle_feature' | 'systeme.maintenance' | 'systeme.astuce'
+
+export const NOTIF_DEFAULTS: Record<NotifKey, boolean> = {
+  'entrainement.rappel_seance': true,
+  'entrainement.programme_matin': true,
+  'entrainement.seance_a_venir': false,
+  'entrainement.nouveau_plan': true,
+  'entrainement.rappel_enregistrement': false,
+  'entrainement.test_suggere': false,
+  'recuperation.rappel_hrv': true,
+  'recuperation.suivi_sommeil': false,
+  'recuperation.alerte_fatigue': true,
+  'recuperation.recup_recommandee': true,
+  'recuperation.conseils_post_seance': false,
+  'nutrition.rappel_repas': false,
+  'nutrition.hydratation': false,
+  'nutrition.timing_nutritionnel': false,
+  'nutrition.recharge_glucidique': true,
+  'nutrition.plan_nutrition': true,
+  'performance.resume_hebdo': true,
+  'performance.resume_mensuel': false,
+  'performance.progression': true,
+  'performance.evolution_charge': false,
+  'performance.zones_maj': false,
+  'coach.suggestions': true,
+  'coach.briefing': true,
+  'coach.analyse_terminee': false,
+  'coach.competences': false,
+  'tokens.quota_80': true,
+  'tokens.quota_95': true,
+  'tokens.quota_epuise': true,
+  'tokens.pack_credite': true,
+  'tokens.plan_expiration': true,
+  'tokens.paiement_echoue': true,
+  'connexions.activite_synchro': false,
+  'connexions.donnee_importee': false,
+  'connexions.reconnexion': true,
+  'connexions.echec_sync': true,
+  'competitions.j7': true,
+  'competitions.j3': true,
+  'competitions.j1': true,
+  'competitions.strategie_dispo': true,
+  'systeme.nouvelle_version': true,
+  'systeme.nouvelle_feature': true,
+  'systeme.maintenance': false,
+  'systeme.astuce': false,
+}
+
+export function defaultFor(key: string): boolean {
+  return NOTIF_DEFAULTS[key as NotifKey] ?? false
+}

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -1,0 +1,69 @@
+// ══════════════════════════════════════════════════════════════
+// Moteur central des notifications.
+//
+// notifyUser(userId, key, payload) :
+//   1. lit les préférences de l'utilisateur (global + par catégorie) ;
+//   2. respecte le toggle (et le défaut si jamais réglé) ;
+//   3. crée la notification IN-APP (cloche, table `notifications`) ;
+//   4. envoie le push sur tous ses appareils (Web Push).
+//
+// Utilisable partout côté serveur (routes API, webhooks, cron). L'in-app
+// marche même sans push configuré ; le push est best-effort par-dessus.
+// ══════════════════════════════════════════════════════════════
+
+import { createServiceClient } from '@/lib/supabase/server'
+import { sendPushToUser } from '@/lib/push/send'
+import { createNotification, createNotificationOnce } from '@/lib/notifications/create'
+import { defaultFor, type NotifKey } from '@/lib/notifications/catalog'
+
+type NotifyPayload = {
+  title: string
+  body: string
+  url?: string
+  // Clé de déduplication (jalon « J-7 », rappel du jour…). Recommandé.
+  dedupKey?: string
+  // true → insère une seule fois pour ce dedupKey (jalon one-shot).
+  once?: boolean
+}
+
+// Renvoie true si l'utilisateur accepte cette catégorie de notification.
+export async function isNotifEnabled(userId: string, key: NotifKey): Promise<boolean> {
+  try {
+    const sb = createServiceClient()
+    const { data } = await sb
+      .from('user_notification_preferences')
+      .select('global_enabled, preferences')
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (data?.global_enabled === false) return false
+    const prefs = (data?.preferences as Record<string, boolean> | null) ?? {}
+    return prefs[key] ?? defaultFor(key)
+  } catch {
+    return defaultFor(key)
+  }
+}
+
+// Notifie UN utilisateur pour une catégorie donnée (respecte ses réglages).
+// Écrit la notif in-app (cloche) PUIS envoie le push. Best-effort de bout en bout.
+export async function notifyUser(userId: string, key: NotifKey, payload: NotifyPayload): Promise<void> {
+  if (!(await isNotifEnabled(userId, key))) return
+  const sb = createServiceClient()
+
+  // 1. In-app (cloche) — visible même sans push configuré / sans appareil.
+  const inApp = { type: key, title: payload.title, body: payload.body, link: payload.url, dedupKey: payload.dedupKey }
+  if (payload.once) await createNotificationOnce(sb, userId, inApp)
+  else await createNotification(sb, userId, inApp)
+
+  // 2. Push Web (best-effort) — no-op si non configuré / aucun appareil.
+  await sendPushToUser(sb, userId, {
+    title: payload.title,
+    body: payload.body,
+    url: payload.url ?? '/',
+    tag: payload.dedupKey ?? key,
+  })
+}
+
+// Notifie plusieurs utilisateurs (cron) — chacun filtré par ses réglages.
+export async function notifyUsers(userIds: string[], key: NotifKey, payload: NotifyPayload): Promise<void> {
+  await Promise.all(userIds.map((id) => notifyUser(id, key, payload).catch(() => {})))
+}

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -1,0 +1,23 @@
+// ══════════════════════════════════════════════════════════════
+// Helper client : émet une notification (in-app + push) pour un événement
+// déclenché côté navigateur. Best-effort, ne jette jamais.
+// ══════════════════════════════════════════════════════════════
+
+export type EmitPayload = {
+  key: string
+  title: string
+  body: string
+  url?: string
+  dedupKey?: string
+  once?: boolean
+}
+
+export function emitNotification(payload: EmitPayload): void {
+  try {
+    void fetch('/api/notifications/emit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch(() => { /* silencieux */ })
+  } catch { /* silencieux */ }
+}

--- a/src/lib/records/processBikeActivity.ts
+++ b/src/lib/records/processBikeActivity.ts
@@ -6,6 +6,7 @@
 // ══════════════════════════════════════════════════════════════
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { notifyUser } from '@/lib/notifications/dispatch'
 
 // d = durée en secondes ; label = distance_label DB ; display = label UI
 export const BIKE_RECORD_DURS: { d: number; label: string; display: string }[] = [
@@ -214,6 +215,19 @@ export async function processBikeActivityRecords(
         processed: false,
         reason:    `insert_failed: ${insErr.message}`,
       }
+    }
+
+    // Notification : nouveau record all-time détecté (le plus valorisant).
+    if (allTimeBeaten.length > 0) {
+      const best = allTimeBeaten[0]
+      const extra = allTimeBeaten.length > 1 ? ` (+${allTimeBeaten.length - 1} autre${allTimeBeaten.length > 2 ? 's' : ''})` : ''
+      void notifyUser(userId, 'performance.progression', {
+        title: 'Nouveau record 💥',
+        body: `${best.display} à ${best.watts} W — nouveau record all-time${extra} !`,
+        url: '/progression',
+        dedupKey: `pr-${activityId}`,
+        once: true,
+      })
     }
   }
 

--- a/src/lib/tokens/limits.ts
+++ b/src/lib/tokens/limits.ts
@@ -7,6 +7,7 @@
 import { createServiceClient } from '@/lib/supabase/server'
 import { getUserTier, isCreatorAccount } from '@/lib/subscriptions/check-quota'
 import { getModelMultiplier } from './multipliers'
+import { notifyUser } from '@/lib/notifications/dispatch'
 
 export interface TokenLimits {
   monthly:     { used: number; limit: number; resets_at: string }
@@ -164,6 +165,27 @@ export async function recordTokenUsage(userId: string, rawTokens: number, meta: 
         .update({ bonus_tokens: Math.max(0, limits.bonus_tokens - fromBonus), updated_at: new Date().toISOString() })
         .eq('user_id', userId)
     }
+
+    // ── Seuils de quota mensuel → notification (une fois par mois) ──
+    // On détecte le FRANCHISSEMENT d'un seuil (80 / 95 / 100 %) grâce à
+    // l'usage AVANT (limits.monthly.used) et APRÈS cette consommation.
+    try {
+      const limit = limits.monthly.limit
+      if (limit > 0) {
+        const prevUsed = limits.monthly.used
+        const newUsed  = prevUsed + Math.min(weighted, remainingPlan)
+        const prev = prevUsed / limit
+        const next = newUsed / limit
+        const period = new Date().toISOString().slice(0, 7)   // YYYY-MM
+        if (prev < 1 && next >= 1) {
+          void notifyUser(userId, 'tokens.quota_epuise', { title: 'Quota épuisé', body: 'Tu as utilisé tout ton quota mensuel. Achète des tokens ou attends le reset.', url: '/settings/subscription', dedupKey: `quota-epuise-${period}`, once: true })
+        } else if (prev < 0.95 && next >= 0.95) {
+          void notifyUser(userId, 'tokens.quota_95', { title: 'Quota à 95%', body: 'Ta limite mensuelle est presque atteinte.', url: '/settings/subscription', dedupKey: `quota-95-${period}`, once: true })
+        } else if (prev < 0.8 && next >= 0.8) {
+          void notifyUser(userId, 'tokens.quota_80', { title: 'Quota à 80%', body: 'Tu approches de ta limite mensuelle.', url: '/settings/subscription', dedupKey: `quota-80-${period}`, once: true })
+        }
+      }
+    } catch { /* best-effort */ }
   } catch (e) {
     console.error('[recordTokenUsage] error:', e)
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "crons": [
-    { "path": "/api/coach/learn", "schedule": "0 3 * * *" }
+    { "path": "/api/coach/learn", "schedule": "0 3 * * *" },
+    { "path": "/api/notifications/dispatch", "schedule": "0 6 * * *" }
   ]
 }


### PR DESCRIPTION
## Résumé
Les ~40 toggles de la page Notifications déclenchent maintenant de **vraies notifications** — cloche in-app (table `notifications`) **et** push Web — chacune filtrée par la préférence de l'utilisateur.

### Moteur central
- `lib/notifications/dispatch.ts` — `notifyUser(userId, key, payload)` : vérifie le toggle global + la catégorie, écrit la notif in-app, envoie le push. `catalog.ts` : clés + valeurs par défaut alignées sur le profil.
- `POST /api/notifications/emit` — émission depuis un événement côté client (utilisateur authentifié).

### Déclencheurs date/heure — cron quotidien (06:00 UTC)
`GET /api/notifications/dispatch` (gardé par `CRON_SECRET`, ajouté à `vercel.json`) :
Compétitions **J-7 / J-3 / J-1**, recharge glucidique, séance du jour, programme du matin, rappel HRV, hydratation, rappel repas, résumé **hebdo** (lundi) / **mensuel** (1er), astuce du jour, plan en expiration.

### Déclencheurs événementiels
- **Quotas 80 / 95 / 100 %** → `recordTokenUsage`
- **Pack crédité** → webhook top-up
- **Paiement échoué** → webhook Stripe
- **Activité synchronisée / échec sync** → route de sync
- **Nouveau record** → `processBikeActivity`
- **Nouveau plan** → `saveToPlanning`
- **Plan nutrition** → `useNutrition`
- **Analyse terminée** → `useAIAnalysis`

### Non couvert (dépend de features non encore construites)
`alerte_fatigue`, `recup_recommandee`, `evolution_charge`, `zones_maj` (nécessitent CTL/ATL/TSB), `suivi_sommeil` (intégration sommeil), `coach.suggestions` / `coach.competences` (moteur de suggestion proactif), broadcasts `systeme.*` (admin). Les rappels intra-journée (repas/hydratation, séance ~1 h avant) sont envoyés une fois par jour faute de cron infra-journalier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMnddmw6NGosWs2RZ4Wa3c)_